### PR TITLE
Publish console app as a .NET Tool to nuget.org

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ steps:
     displayName: 'Creating Nuget Packages'
     inputs:
       command: 'pack'
-      packagesToPack: '**/*.csproj;!**/*.Tests.csproj;!**/*.Console.csproj;!**/*.Web.csproj;!**/*.Samples.csproj'
+      packagesToPack: '**/src/*.csproj;!**/*.Tests.csproj;!**/*.Web.csproj;!**/Demo.*.csproj'
       versioningScheme: 'byBuildNumber'
   - task: SonarCloudAnalyze@1
     displayName: 'Run Code Analysis and Publish Quality Gate Result'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ steps:
     displayName: 'Creating Nuget Packages'
     inputs:
       command: 'pack'
-      packagesToPack: '**/src/*.csproj;!**/*.Tests.csproj;!**/*.Web.csproj;!**/Demo.*.csproj'
+      packagesToPack: '**/src/**/*.csproj;!**/*.Tests.csproj;!**/*.Web.csproj;!**/Demo.*.csproj'
       versioningScheme: 'byBuildNumber'
   - task: SonarCloudAnalyze@1
     displayName: 'Run Code Analysis and Publish Quality Gate Result'

--- a/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
+++ b/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
@@ -39,4 +39,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\images\icon.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
+++ b/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Title>Atc Generator CLI</Title>
+    <Title>Atc API Generator CLI</Title>
     <Authors>Atc-net</Authors>
     <Description>Atc is a collection of classes and extension methods for common functionality.</Description>
     <PackageProjectUrl>https://github.com/atc-net/atc/tree/master/src/Atc.Rest.ApiGenerator.Console</PackageProjectUrl>

--- a/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
+++ b/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
@@ -13,8 +13,8 @@
     <RepositoryUrl>https://github.com/atc-net/atc</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageId>atc-cli</PackageId>
-    <AssemblyName>atc-cli</AssemblyName>
+    <PackageId>atc-api-gen</PackageId>
+    <AssemblyName>atc-api</AssemblyName>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsPackable>true</IsPackable>

--- a/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
+++ b/src/Atc.Rest.ApiGenerator.Console/Atc.Rest.ApiGenerator.Console.csproj
@@ -3,6 +3,23 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Title>Atc Generator CLI</Title>
+    <Authors>Atc-net</Authors>
+    <Description>Atc is a collection of classes and extension methods for common functionality.</Description>
+    <PackageProjectUrl>https://github.com/atc-net/atc/tree/master/src/Atc.Rest.ApiGenerator.Console</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/atc-net/atc/master/images/icon.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
+    <RepositoryUrl>https://github.com/atc-net/atc</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageId>atc-cli</PackageId>
+    <AssemblyName>atc-cli</AssemblyName>
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This will allow us to conveniently install the console app via `dotnet tool install --global [package name]` and use it anywhere and also conveniently update it like you would update any nuget package