### PR TITLE
Retrieve route parameters from GlobalPathParameters.

### DIFF
--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateServerApiXunitTestEndpointTestHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateServerApiXunitTestEndpointTestHelper.cs
@@ -429,7 +429,7 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
             return $"{relativeRefPath}{relativeRefQuery}";
         }
 
-        private static string RenderRelativeRefPath(string route, List<OpenApiParameter> routeParameters, IDictionary<string, OpenApiSchema> componentsSchemas, bool useForBadRequest)
+        private static string RenderRelativeRefPath(string route, IList<OpenApiParameter> routeParameters, IDictionary<string, OpenApiSchema> componentsSchemas, bool useForBadRequest)
         {
             var sa = route.Split('/');
             for (int i = 0; i < sa.Length; i++)
@@ -443,7 +443,7 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                     .Replace("{", string.Empty, StringComparison.Ordinal)
                     .Replace("}", string.Empty, StringComparison.Ordinal);
 
-                var fromRoute = routeParameters.Find(x => x.Name == pn);
+                var fromRoute = routeParameters.First(x => x.Name == pn);
                 sa[i] = PropertyValueGenerator(fromRoute, componentsSchemas, useForBadRequest, null);
             }
 

--- a/src/Atc.Rest.ApiGenerator/Models/EndpointMethodMetadata.cs
+++ b/src/Atc.Rest.ApiGenerator/Models/EndpointMethodMetadata.cs
@@ -70,11 +70,11 @@ namespace Atc.Rest.ApiGenerator.Models
             return GetHeaderRequiredParameters().Count > 0;
         }
 
-        public List<OpenApiParameter> GetRouteParameters()
+        public IList<OpenApiParameter> GetRouteParameters()
         {
             return ContractParameter == null
                 ? new List<OpenApiParameter>()
-                : ContractParameter.ApiOperation.Parameters.GetAllFromRoute();
+                : ContractParameter.GlobalPathParameters;
         }
 
         public List<OpenApiParameter> GetHeaderParameters()


### PR DESCRIPTION
This fixes a null pointer exception during generation with the host option. The problem is that the Parameters collection does not contain the parameter from the route. This can be retrieved from the GlobalPathParameters collection.