### PR TITLE
Add support specifying multiple OAuth token issuers

### DIFF
--- a/sample/Demo.Api.Full/appsettings.Development.json
+++ b/sample/Demo.Api.Full/appsettings.Development.json
@@ -22,7 +22,7 @@
   //  */
   //  "TenantId": "common",
   //  "Audience": "[App Identifier URI of the Azure AD App Registration or api://[ClientId]]",
-  //  "Issuer": "[The token iss claim also specified as the access_token_issuer from the OpenID configuration]",
+  //  "Issuer": "[The token iss claim also specified as the issuer or access_token_issuer from the OpenID configuration]",
   //  /*
   //    A string array of accepted audiences
   //  */
@@ -35,9 +35,9 @@
   //    A string array of accepted issuers
   //  */
   //  "ValidIssuers": [
-  //    "The token iss claim also specified as the access_token_issuer from the OpenID configuration",
-  //    "The token iss claim also specified as the access_token_issuer from the OpenID configuration",
-  //    "The token iss claim also specified as the access_token_issuer from the OpenID configuration"
+  //    "The token iss claim also specified as the issuer or access_token_issuer from the OpenID configuration",
+  //    "The token iss claim also specified as the issuer or access_token_issuer from the OpenID configuration",
+  //    "The token iss claim also specified as the issuer or access_token_issuer from the OpenID configuration"
   //  ]
   //},
 

--- a/sample/Demo.Api.Full/appsettings.Development.json
+++ b/sample/Demo.Api.Full/appsettings.Development.json
@@ -21,8 +21,24 @@
   //    - 'adfs' (For on-prem ADFS)
   //  */
   //  "TenantId": "common",
-  //  "Audience": "[App Identifier URI of the Azure AD App Registration]",
-  //  "Issuer": "[The token iss claim also specified as the access_token_issuer from the OpenID configuration]"
+  //  "Audience": "[App Identifier URI of the Azure AD App Registration or api://[ClientId]]",
+  //  "Issuer": "[The token iss claim also specified as the access_token_issuer from the OpenID configuration]",
+  //  /*
+  //    A string array of accepted audiences
+  //  */
+  //  "ValidAudiences": [
+  //    "[App Identifier URI of the Azure AD App Registration or api://[ClientId]]",
+  //    "[App Identifier URI of the Azure AD App Registration or api://[ClientId]]",
+  //    "[App Identifier URI of the Azure AD App Registration or api://[ClientId]]"
+  //  ],
+  //  /*
+  //    A string array of accepted issuers
+  //  */
+  //  "ValidIssuers": [
+  //    "The token iss claim also specified as the access_token_issuer from the OpenID configuration",
+  //    "The token iss claim also specified as the access_token_issuer from the OpenID configuration",
+  //    "The token iss claim also specified as the access_token_issuer from the OpenID configuration"
+  //  ]
   //},
 
   "Logging": {

--- a/src/Atc.Rest.Extended/Options/ConfigureAuthorizationOptions.cs
+++ b/src/Atc.Rest.Extended/Options/ConfigureAuthorizationOptions.cs
@@ -67,22 +67,14 @@ namespace Atc.Rest.Extended.Options
                 ValidAudiences = apiOptions.Authorization.ValidAudiences,
             };
 
-            if (!apiOptions.Authorization.ValidIssuers.Any())
-            {
-                apiOptions.Authorization.ValidIssuers = new List<string>
-                {
-                    apiOptions.Authorization.Issuer
-                };
-            }
-
             options.TokenValidationParameters.ValidateIssuer =
                 !string.IsNullOrWhiteSpace(apiOptions.Authorization.Issuer) ||
-                apiOptions.Authorization.ValidIssuers.Any();
+                apiOptions.Authorization.ValidIssuers?.Any() == true;
 
             if (options.TokenValidationParameters.ValidateIssuer)
             {
                 options.TokenValidationParameters.ValidIssuer = apiOptions.Authorization.Issuer;
-                options.TokenValidationParameters.ValidIssuers = apiOptions.Authorization.ValidIssuers;
+                options.TokenValidationParameters.ValidIssuers = apiOptions.Authorization.ValidIssuers ?? new List<string>();
             }
         }
 

--- a/src/Atc.Rest.Extended/Options/ConfigureAuthorizationOptions.cs
+++ b/src/Atc.Rest.Extended/Options/ConfigureAuthorizationOptions.cs
@@ -50,7 +50,7 @@ namespace Atc.Rest.Extended.Options
                     $"Missing ClientId and Audience. Please verify the {AuthorizationOptions.ConfigurationSectionName} section in appsettings and ensure that the ClientId or Audience is specified");
             }
 
-            if (!apiOptions.Authorization.ValidAudiences.Any())
+            if (apiOptions.Authorization.ValidAudiences?.Any() == false)
             {
                 apiOptions.Authorization.ValidAudiences = new List<string>
                 {

--- a/src/Atc.Rest.Extended/Options/ConfigureAuthorizationOptions.cs
+++ b/src/Atc.Rest.Extended/Options/ConfigureAuthorizationOptions.cs
@@ -67,14 +67,22 @@ namespace Atc.Rest.Extended.Options
                 ValidAudiences = apiOptions.Authorization.ValidAudiences,
             };
 
-            if (!string.IsNullOrWhiteSpace(apiOptions.Authorization.Issuer))
+            if (!apiOptions.Authorization.ValidIssuers.Any())
             {
-                options.TokenValidationParameters.ValidateIssuer = true;
-                options.TokenValidationParameters.ValidIssuer = apiOptions.Authorization.Issuer;
+                apiOptions.Authorization.ValidIssuers = new List<string>
+                {
+                    apiOptions.Authorization.Issuer
+                };
             }
-            else
+
+            options.TokenValidationParameters.ValidateIssuer =
+                !string.IsNullOrWhiteSpace(apiOptions.Authorization.Issuer) ||
+                apiOptions.Authorization.ValidIssuers.Any();
+
+            if (options.TokenValidationParameters.ValidateIssuer)
             {
-                options.TokenValidationParameters.ValidateIssuer = false;
+                options.TokenValidationParameters.ValidIssuer = apiOptions.Authorization.Issuer;
+                options.TokenValidationParameters.ValidIssuers = apiOptions.Authorization.ValidIssuers;
             }
         }
 

--- a/src/Atc.Rest/Options/AuthorizationOptions.cs
+++ b/src/Atc.Rest/Options/AuthorizationOptions.cs
@@ -49,5 +49,7 @@ namespace Atc.Rest.Options
         public string Issuer { get; set; } = string.Empty;
 
         public List<string> ValidAudiences { get; set; } = new List<string>();
+
+        public List<string> ValidIssuers { get; set; } = new List<string>();
     }
 }

--- a/test/Atc.Rest.Extended.Tests/Options/ConfigureAuthorizationOptionsTests.cs
+++ b/test/Atc.Rest.Extended.Tests/Options/ConfigureAuthorizationOptionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Atc.Rest.Extended.Options;
+﻿using System.Collections.Generic;
+using Atc.Rest.Extended.Options;
 using AutoFixture.Xunit2;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
@@ -68,6 +69,48 @@ namespace Atc.Rest.Extended.Tests.Options
             var options = new AuthenticationOptions();
             new ConfigureAuthorizationOptions(apiOptions, null).PostConfigure(string.Empty, options);
             options.DefaultScheme.Should().Be(JwtBearerDefaults.AuthenticationScheme);
+        }
+
+        [Theory, AutoData]
+        public void PostConfigure_JwtBearerOptions_ValidateIssuer_False_If_No_Issuers(RestApiExtendedOptions apiOptions)
+        {
+            apiOptions.Authorization.Issuer = null;
+            apiOptions.Authorization.ValidIssuers = new List<string>();
+
+            var options = new JwtBearerOptions();
+            new ConfigureAuthorizationOptions(apiOptions, null).PostConfigure(string.Empty, options);
+            options.TokenValidationParameters.ValidateIssuer.Should().BeFalse();
+        }
+
+        [Theory, AutoData]
+        public void PostConfigure_JwtBearerOptions_ValidateIssuer_True_With_ValidIssuers(RestApiExtendedOptions apiOptions)
+        {
+            apiOptions.Authorization.Issuer = null;
+
+            var options = new JwtBearerOptions();
+            new ConfigureAuthorizationOptions(apiOptions, null).PostConfigure(string.Empty, options);
+            options.TokenValidationParameters.ValidateIssuer.Should().BeTrue();
+        }
+
+        [Theory, AutoData]
+        public void PostConfigure_JwtBearerOptions_ValidateIssuer_True_With_Issuer(RestApiExtendedOptions apiOptions)
+        {
+            apiOptions.Authorization.ValidIssuers = new List<string>();
+
+            var options = new JwtBearerOptions();
+            new ConfigureAuthorizationOptions(apiOptions, null).PostConfigure(string.Empty, options);
+            options.TokenValidationParameters.ValidateIssuer.Should().BeTrue();
+        }
+
+        [Theory, AutoData]
+        public void PostConfigure_JwtBearerOptions_ValidateIssuer_False_With_ValidIssuers_Null(RestApiExtendedOptions apiOptions)
+        {
+            apiOptions.Authorization.Issuer = null;
+            apiOptions.Authorization.ValidIssuers = null;
+
+            var options = new JwtBearerOptions();
+            new ConfigureAuthorizationOptions(apiOptions, null).PostConfigure(string.Empty, options);
+            options.TokenValidationParameters.ValidateIssuer.Should().BeFalse();
         }
     }
 }


### PR DESCRIPTION
This is to support running endpoint integration tests authorized as confidential clients