### PR TITLE
Make sure decimal numbers are parsed correctly no matter computer regional settings

### DIFF
--- a/docs/CodeDoc/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.SyntaxFactories.md
+++ b/docs/CodeDoc/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.SyntaxFactories.md
@@ -652,6 +652,11 @@ public static class SyntaxTokenListFactory
 ```csharp
 SyntaxTokenList InternalStaticKeyword(bool withLeadingLineFeed = False, bool withTrailingSpace = True)
 ```
+#### PrivateAsyncKeyword
+
+```csharp
+SyntaxTokenList PrivateAsyncKeyword(bool withLeadingLineFeed = False, bool withTrailingSpace = True)
+```
 #### PrivateReadonlyKeyword
 
 ```csharp

--- a/docs/CodeDoc/Atc.CodeAnalysis.CSharp/IndexExtended.md
+++ b/docs/CodeDoc/Atc.CodeAnalysis.CSharp/IndexExtended.md
@@ -135,6 +135,7 @@
 - [SyntaxTokenListFactory](Atc.CodeAnalysis.CSharp.SyntaxFactories.md#syntaxtokenlistfactory)
   -  Static Methods
      - InternalStaticKeyword(bool withLeadingLineFeed = False, bool withTrailingSpace = True)
+     - PrivateAsyncKeyword(bool withLeadingLineFeed = False, bool withTrailingSpace = True)
      - PrivateReadonlyKeyword(bool withTrailingSpace = True)
      - ProtectedReadOnlyKeyword(bool withLeadingLineFeed = False, bool withTrailingSpace = True)
      - ProtectedStaticKeyword(bool withLeadingLineFeed = False, bool withTrailingSpace = True)

--- a/src/Atc.CodeAnalysis.CSharp/SyntaxFactories/SyntaxLiteralExpressionFactory.cs
+++ b/src/Atc.CodeAnalysis.CSharp/SyntaxFactories/SyntaxLiteralExpressionFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -16,16 +17,19 @@ namespace Atc.CodeAnalysis.CSharp.SyntaxFactories
 
             if (syntaxKind == SyntaxKind.NumericLiteralExpression)
             {
-                if (int.TryParse(value, out var parsedInt))
+                if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedInt))
                 {
                     return SyntaxFactory.LiteralExpression(syntaxKind, SyntaxFactory.Literal(parsedInt));
                 }
 
-                value = value.Replace(".", ",", StringComparison.Ordinal);
-                if (double.TryParse(value, out var parsedDouble))
+                value = value.Replace(",", ".", StringComparison.Ordinal);
+                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedDouble))
                 {
                     return SyntaxFactory.LiteralExpression(syntaxKind, SyntaxFactory.Literal(parsedDouble));
                 }
+
+                // Value cannot be parsed as number.
+                throw new ArgumentOutOfRangeException(nameof(value), "Cannot parse value as number");
             }
 
             return SyntaxFactory.LiteralExpression(syntaxKind, SyntaxFactory.Literal(value));

--- a/test/Atc.CodeAnalysis.CSharp.Tests/CodeComplianceTests.cs
+++ b/test/Atc.CodeAnalysis.CSharp.Tests/CodeComplianceTests.cs
@@ -37,7 +37,6 @@ namespace Atc.CodeAnalysis.CSharp.Tests
             typeof(SyntaxIfStatementFactory),
             typeof(SyntaxInterfaceDeclarationFactory),
             typeof(SyntaxInterpolatedFactory),
-            typeof(SyntaxLiteralExpressionFactory),
             typeof(SyntaxMemberAccessExpressionFactory),
             typeof(SyntaxNameEqualsFactory),
             typeof(SyntaxObjectCreationExpressionFactory),

--- a/test/Atc.CodeAnalysis.CSharp.Tests/SyntaxFactories/SyntaxLiteralExpressionFactoryTests.cs
+++ b/test/Atc.CodeAnalysis.CSharp.Tests/SyntaxFactories/SyntaxLiteralExpressionFactoryTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Globalization;
+using Atc.CodeAnalysis.CSharp.SyntaxFactories;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Atc.CodeAnalysis.CSharp.Tests.SyntaxFactories
+{
+    public class SyntaxLiteralExpressionFactoryTests
+    {
+        [Theory]
+        [InlineData("1.01")]
+        [InlineData("1000.42")]
+        [InlineData("0")]
+        [InlineData("42")]
+        [InlineData("-42")]
+        [InlineData("12,345")]
+        public void ShouldParseNumber(string value)
+        {
+            // Act
+            var result = SyntaxLiteralExpressionFactory.Create(value, SyntaxKind.NumericLiteralExpression);
+
+            // Assert
+            Assert.Equal(SyntaxKind.NumericLiteralExpression, result.Kind());
+            Assert.Equal(value.Replace(",", ".", StringComparison.Ordinal), result.ToString());
+        }
+
+        [Theory]
+        [InlineData("1.0a")]
+        [InlineData("ABC")]
+        [InlineData("")]
+        public void ShouldFailOnInvalidNumber(string value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => SyntaxLiteralExpressionFactory.Create(value, SyntaxKind.NumericLiteralExpression));
+        }
+
+        [Theory]
+        [InlineData("1.0a")]
+        [InlineData("ABC")]
+        [InlineData("")]
+        public void ShouldParseInvalidNumberAsString(string value)
+        {
+            // Act
+            var result = SyntaxLiteralExpressionFactory.Create(value);
+
+            // Assert
+            Assert.Equal(SyntaxKind.StringLiteralExpression, result.Kind());
+            Assert.Equal($"\"{value}\"", result.ToString());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(42)]
+        [InlineData(-10)]
+        public void ShouldParseInteger(int value)
+        {
+            // Act
+            var result = SyntaxLiteralExpressionFactory.Create(value);
+
+            // Assert
+            Assert.Equal(SyntaxKind.NumericLiteralExpression, result.Kind());
+            Assert.Equal(value.ToString(CultureInfo.InvariantCulture), result.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Code generation of range parameters with decimal numbers was generating incorrect integer value instead of decimal.

Note: Introduce exception when unable to parse as number, change in behavior that should not affect current use unless regional settings would have caused wrong code generation.

Example of wrongly generated code in demo project.

![image](https://user-images.githubusercontent.com/5988733/97802840-7f105f80-1c46-11eb-8f86-5fe42c8025a2.png)
