### PR TITLE
Prevent handling exception if response has started

### DIFF
--- a/src/Atc.Rest/Middleware/ExceptionTelemetryMiddleware.cs
+++ b/src/Atc.Rest/Middleware/ExceptionTelemetryMiddleware.cs
@@ -41,6 +41,11 @@ namespace Atc.Rest.Middleware
             {
                 client.TrackException(ex);
 
+                if (context.Response.HasStarted)
+                {
+                    throw;
+                }
+
                 requestFailed = true;
             }
 


### PR DESCRIPTION
Setting the StatusCode when a response has already started will throw, and log multiple exceptions to telemetry.