### PR TITLE
Fix potential incorrect order of using statement in generated endpoint tests

### DIFF
--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateServerApiXunitTestEndpointTestHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateServerApiXunitTestEndpointTestHelper.cs
@@ -27,9 +27,8 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                 throw new ArgumentNullException(nameof(endpointMethodMetadata));
             }
 
-            var usingStatements = GetUsingStatements(hostProjectOptions, endpointMethodMetadata);
             var sb = new StringBuilder();
-            foreach (var statement in usingStatements)
+            foreach (var statement in GetUsingStatements(hostProjectOptions, endpointMethodMetadata))
             {
                 sb.AppendLine($"using {statement};");
             }


### PR DESCRIPTION
Depending on the provided `ProjectPrefixName` name when executing `act-gen`, the generated endpoint test could produce "incorrect" ordering of the using statements in the generated files.