### PR TITLE
Invalid constructed json objects in generated test

### DIFF
--- a/src/Atc.OpenApi/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Atc.OpenApi/Extensions/OpenApiSchemaExtensions.cs
@@ -557,6 +557,8 @@ namespace Microsoft.OpenApi.Models
                         : "int";
                 case OpenApiDataTypeConstants.Boolean:
                     return "bool";
+                case OpenApiDataTypeConstants.Array:
+                    return "array";
             }
 
             if (!string.IsNullOrEmpty(schema.Format))

--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestHelper.cs
@@ -270,10 +270,6 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                 sb.AppendLine(indentSpaces, "var sb = new StringBuilder();");
                 sb.AppendLine(indentSpaces, WrapAppendLine("{"));
             }
-            else
-            {
-                sb.AppendLine(indentSpaces, WrapAppendLine($"{jsonSpaces}  {{"));
-            }
 
             foreach (var schemaProperty in schema.Properties)
             {
@@ -292,7 +288,7 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                     var schemaForDataType = endpointMethodMetadata.ComponentsSchemas.FirstOrDefault(x => x.Key.Equals(dataType, StringComparison.OrdinalIgnoreCase));
                     sb.AppendLine(
                         indentSpaces,
-                        WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\":"));
+                        WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": {{"));
                     AppendNewModelAsJson(indentSpaces, sb, endpointMethodMetadata, schemaForDataType.Value, badRequestPropertyName, -1, null, jsonIndentLevel + 1);
                 }
                 else

--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestHelper.cs
@@ -261,16 +261,18 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                 throw new ArgumentNullException(nameof(schema));
             }
 
+            static string WrapAppendLine(string str) => $"sb.AppendLine(\"{str}\");";
+
             var countString = 0;
             var jsonSpaces = string.Empty.PadLeft(jsonIndentLevel * 2);
             if (jsonIndentLevel == 0)
             {
                 sb.AppendLine(indentSpaces, "var sb = new StringBuilder();");
-                sb.AppendLine(indentSpaces, "sb.AppendLine(\"{\");");
+                sb.AppendLine(indentSpaces, WrapAppendLine("{"));
             }
             else
             {
-                sb.AppendLine(indentSpaces, "sb.AppendLine(\"" + jsonSpaces + "{\");");
+                sb.AppendLine(indentSpaces, WrapAppendLine($"{jsonSpaces}  {{"));
             }
 
             foreach (var schemaProperty in schema.Properties)
@@ -290,7 +292,7 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                     var schemaForDataType = endpointMethodMetadata.ComponentsSchemas.FirstOrDefault(x => x.Key.Equals(dataType, StringComparison.OrdinalIgnoreCase));
                     sb.AppendLine(
                         indentSpaces,
-                        $"sb.AppendLine(\"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": \\\"{schemaForDataType.Value.GetModelName()}\\\"\");");
+                        WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\":"));
                     AppendNewModelAsJson(indentSpaces, sb, endpointMethodMetadata, schemaForDataType.Value, badRequestPropertyName, -1, null, jsonIndentLevel + 1);
                 }
                 else
@@ -311,13 +313,13 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                             sb.AppendLine(
                                 indentSpaces,
                                 propertyValueGenerated.Equals("null", StringComparison.Ordinal)
-                                    ? $"sb.AppendLine(\"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": {propertyValueGenerated}{trailingChar}\");"
-                                    : $"sb.AppendLine(\"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": \\\"{propertyValueGenerated}\\\"{trailingChar}\");");
+                                    ? WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": {propertyValueGenerated}{trailingChar}")
+                                    : WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": \\\"{propertyValueGenerated}\\\"{trailingChar}"));
                             break;
                         default:
                             sb.AppendLine(
                                 indentSpaces,
-                                $"sb.AppendLine(\"  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": \\\"{propertyValueGenerated}\\\"{trailingChar}\");");
+                                WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": \\\"{propertyValueGenerated}\\\"{trailingChar}"));
                             break;
                     }
                 }
@@ -325,12 +327,12 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
 
             if (jsonIndentLevel == 0)
             {
-                sb.AppendLine(indentSpaces, "sb.AppendLine(\"}\");");
+                sb.AppendLine(indentSpaces, WrapAppendLine($"}}"));
                 sb.AppendLine(indentSpaces, $"var {variableName} = sb.ToString();");
             }
             else
             {
-                sb.AppendLine(indentSpaces, "sb.AppendLine(\"" + jsonSpaces + "}\");");
+                sb.AppendLine(indentSpaces, WrapAppendLine($"{jsonSpaces}}}"));
             }
         }
 

--- a/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestHelper.cs
+++ b/src/Atc.Rest.ApiGenerator/Helpers/XunitTest/GenerateXunitTestHelper.cs
@@ -261,14 +261,12 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                 throw new ArgumentNullException(nameof(schema));
             }
 
-            static string WrapAppendLine(string str) => $"sb.AppendLine(\"{str}\");";
-
             var countString = 0;
             var jsonSpaces = string.Empty.PadLeft(jsonIndentLevel * 2);
             if (jsonIndentLevel == 0)
             {
                 sb.AppendLine(indentSpaces, "var sb = new StringBuilder();");
-                sb.AppendLine(indentSpaces, WrapAppendLine("{"));
+                sb.AppendLine(indentSpaces, WrapInAppendLine("{"));
             }
 
             foreach (var schemaProperty in schema.Properties)
@@ -282,53 +280,44 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                 var useForBadRequest = !string.IsNullOrEmpty(badRequestPropertyName) &&
                                        schemaProperty.Key.Equals(badRequestPropertyName, StringComparison.Ordinal);
                 string dataType = schemaProperty.Value.GetDataType();
-                string propertyValueGenerated = PropertyValueGenerator(schemaProperty, endpointMethodMetadata.ComponentsSchemas, useForBadRequest, itemNumber, null);
+                string propertyValueGenerated =
+                    WrapInQuotes(
+                        PropertyValueGenerator(schemaProperty, endpointMethodMetadata.ComponentsSchemas, useForBadRequest, itemNumber, null),
+                        schemaProperty);
                 if ("NEW-INSTANCE".Equals(propertyValueGenerated, StringComparison.Ordinal))
                 {
                     var schemaForDataType = endpointMethodMetadata.ComponentsSchemas.FirstOrDefault(x => x.Key.Equals(dataType, StringComparison.OrdinalIgnoreCase));
                     sb.AppendLine(
                         indentSpaces,
-                        WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": {{"));
+                        WrapInAppendLine($"{jsonSpaces}  {WrapInQuotes(schemaProperty.Key.EnsureFirstCharacterToUpper())}: {{"));
                     AppendNewModelAsJson(indentSpaces, sb, endpointMethodMetadata, schemaForDataType.Value, badRequestPropertyName, -1, null, jsonIndentLevel + 1);
                 }
                 else
                 {
-                    switch (dataType)
+                    if (dataType == "string" && !schemaProperty.Value.IsFormatTypeOfEmail())
                     {
-                        case "string":
-                            if (!schemaProperty.Value.IsFormatTypeOfEmail())
-                            {
-                                if (countString > 0 && !propertyValueGenerated.Equals("null", StringComparison.Ordinal))
-                                {
-                                    propertyValueGenerated = $"{propertyValueGenerated}{countString}";
-                                }
+                        if (countString > 0 && !propertyValueGenerated.Equals("null", StringComparison.Ordinal))
+                        {
+                            propertyValueGenerated = $"{propertyValueGenerated}{countString}";
+                        }
 
-                                countString++;
-                            }
-
-                            sb.AppendLine(
-                                indentSpaces,
-                                propertyValueGenerated.Equals("null", StringComparison.Ordinal)
-                                    ? WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": {propertyValueGenerated}{trailingChar}")
-                                    : WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": \\\"{propertyValueGenerated}\\\"{trailingChar}"));
-                            break;
-                        default:
-                            sb.AppendLine(
-                                indentSpaces,
-                                WrapAppendLine($"{jsonSpaces}  \\\"{schemaProperty.Key.EnsureFirstCharacterToUpper()}\\\": \\\"{propertyValueGenerated}\\\"{trailingChar}"));
-                            break;
+                        countString++;
                     }
+
+                    sb.AppendLine(
+                               indentSpaces,
+                               WrapInAppendLine($"{jsonSpaces}  {WrapInQuotes(schemaProperty.Key.EnsureFirstCharacterToUpper())}: {propertyValueGenerated}{trailingChar}"));
                 }
             }
 
             if (jsonIndentLevel == 0)
             {
-                sb.AppendLine(indentSpaces, WrapAppendLine($"}}"));
+                sb.AppendLine(indentSpaces, WrapInAppendLine($"}}"));
                 sb.AppendLine(indentSpaces, $"var {variableName} = sb.ToString();");
             }
             else
             {
-                sb.AppendLine(indentSpaces, WrapAppendLine($"{jsonSpaces}}}"));
+                sb.AppendLine(indentSpaces, WrapInAppendLine($"{jsonSpaces}}}"));
             }
         }
 
@@ -374,7 +363,7 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
                 return "NEW-INSTANCE";
             }
 
-            if (schema.Value.Type == "array")
+            if (schema.Value.GetDataType() == "array")
             {
                 // TO-DO: Imp. this.
                 return "null";
@@ -382,5 +371,23 @@ namespace Atc.Rest.ApiGenerator.Helpers.XunitTest
 
             return "null";
         }
+
+        private static string WrapInQuotes(string typeTestValue, KeyValuePair<string, OpenApiSchema> schema)
+        {
+            var dataType = schema.Value.GetDataType();
+            return (typeTestValue, dataType) switch
+            {
+                (_, "double") => typeTestValue,
+                (_, "long") => typeTestValue,
+                (_, "int") => typeTestValue,
+                ("null", _) => typeTestValue,
+                ("NEW-INSTANCE", _) => typeTestValue,
+                _ => WrapInQuotes(typeTestValue)
+            };
+        }
+
+        private static string WrapInQuotes(string str) => $"\\\"{str}\\\"";
+
+        private static string WrapInAppendLine(string str) => $"sb.AppendLine(\"{str}\");";
     }
 }


### PR DESCRIPTION
Attempts to fix #25 
Fixes:
- Invalid quotes around data type that should not have quotes. (i.e. integer, number, decimal)
- Fix indentation

Note that I have moved curly brackets for nested objects to be defined on the same line as the object parameter to follow normal json formatting. 

Screenshot of how the json object will be generated now
![image](https://user-images.githubusercontent.com/13435947/99230443-9e36f180-27ef-11eb-8794-598e1180eded.png)

With these changes the Bad Request test only fails for the intended parameter. (In the above example the bad request parameter is `IdTag` on line 76)