### PR TITLE
New ResultBase assertions, tweaks to existing

### DIFF
--- a/docs/CodeDoc/Atc.Rest.ApiGenerator/Atc.Rest.ApiGenerator.Models.md
+++ b/docs/CodeDoc/Atc.Rest.ApiGenerator/Atc.Rest.ApiGenerator.Models.md
@@ -50,6 +50,16 @@ SegmentName
 ### Methods
 
 
+#### Equals
+
+```csharp
+bool Equals(object obj)
+```
+#### GetHashCode
+
+```csharp
+int GetHashCode()
+```
 #### ToString
 
 ```csharp

--- a/docs/CodeDoc/Atc.Rest.ApiGenerator/IndexExtended.md
+++ b/docs/CodeDoc/Atc.Rest.ApiGenerator/IndexExtended.md
@@ -181,6 +181,8 @@
      - SchemaKey
      - SegmentName
   -  Methods
+     - Equals(object obj)
+     - GetHashCode()
      - ToString()
 - [ApiProjectOptions](Atc.Rest.ApiGenerator.Models.md#apiprojectoptions)
   -  Properties

--- a/docs/CodeDoc/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.md
+++ b/docs/CodeDoc/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.md
@@ -8,10 +8,30 @@
 <br />
 
 
-## NotFoundResultAssertions
+## AcceptedResultAssertions
 
 ```csharp
-public class NotFoundResultAssertions : ReferenceTypeAssertions<ContentResult, NotFoundResultAssertions>
+public class AcceptedResultAssertions : ContentResultAssertions<AcceptedResultAssertions>
+```
+
+
+<br />
+
+
+## BadRequestResultAssertions
+
+```csharp
+public class BadRequestResultAssertions : ErrorContentResultAssertions<BadRequestResultAssertions>
+```
+
+
+<br />
+
+
+## ContentResultAssertions&lt;TAssertions&gt;
+
+```csharp
+public abstract class ContentResultAssertions&lt;TAssertions&gt; : ReferenceTypeAssertions<ContentResult, ContentResultAssertions<TAssertions>>
 ```
 
 ### Methods
@@ -20,13 +40,46 @@ public class NotFoundResultAssertions : ReferenceTypeAssertions<ContentResult, N
 #### WithContent
 
 ```csharp
-AndWhichConstraint<NotFoundResultAssertions, ContentResult> WithContent(T expectedContent, string because = , object[] becauseArgs)
+AndWhichConstraint<TAssertions, ContentResult> WithContent(T expectedContent, string because = , object[] becauseArgs)
 ```
+
+<br />
+
+
+## ErrorContentResultAssertions&lt;TAssertions&gt;
+
+```csharp
+public abstract class ErrorContentResultAssertions&lt;TAssertions&gt; : ContentResultAssertions<TAssertions>
+```
+
+### Methods
+
+
 #### WithErrorMessage
 
 ```csharp
-AndWhichConstraint<NotFoundResultAssertions, ContentResult> WithErrorMessage(string expectedErrorMessage, string because = , object[] becauseArgs)
+AndWhichConstraint<TAssertions, ContentResult> WithErrorMessage(string expectedErrorMessage, string because = , object[] becauseArgs)
 ```
+
+<br />
+
+
+## NoContentResultAssertions
+
+```csharp
+public class NoContentResultAssertions : ContentResultAssertions<NoContentResultAssertions>
+```
+
+
+<br />
+
+
+## NotFoundResultAssertions
+
+```csharp
+public class NotFoundResultAssertions : ErrorContentResultAssertions<NotFoundResultAssertions>
+```
+
 
 <br />
 
@@ -45,6 +98,11 @@ public class OkResultAssertions : ReferenceTypeAssertions<OkObjectResult, OkResu
 ```csharp
 AndWhichConstraint<OkResultAssertions, OkObjectResult> WithContent(T expectedContent, string because = , object[] becauseArgs)
 ```
+#### WithContentOfType
+
+```csharp
+AndWhichConstraint<ObjectAssertions, T> WithContentOfType(string because = , object[] becauseArgs)
+```
 
 <br />
 
@@ -58,6 +116,21 @@ public class ResultAssertions : ReferenceTypeAssertions<ActionResult, ResultAsse
 ### Methods
 
 
+#### BeAcceptedResult
+
+```csharp
+AcceptedResultAssertions BeAcceptedResult(string because = , object[] becauseArgs)
+```
+#### BeBadRequestResult
+
+```csharp
+BadRequestResultAssertions BeBadRequestResult(string because = , object[] becauseArgs)
+```
+#### BeNoContentResult
+
+```csharp
+NoContentResultAssertions BeNoContentResult(string because = , object[] becauseArgs)
+```
 #### BeNotFoundResult
 
 ```csharp

--- a/docs/CodeDoc/Atc.Rest.FluentAssertions/Index.md
+++ b/docs/CodeDoc/Atc.Rest.FluentAssertions/Index.md
@@ -13,6 +13,11 @@
 
 ## [Atc.Rest.FluentAssertions](Atc.Rest.FluentAssertions.md)
 
+- [AcceptedResultAssertions](Atc.Rest.FluentAssertions.md#acceptedresultassertions)
+- [BadRequestResultAssertions](Atc.Rest.FluentAssertions.md#badrequestresultassertions)
+- [ContentResultAssertions&lt;TAssertions&gt;](Atc.Rest.FluentAssertions.md#contentresultassertions&lt;tassertions&gt;)
+- [ErrorContentResultAssertions&lt;TAssertions&gt;](Atc.Rest.FluentAssertions.md#errorcontentresultassertions&lt;tassertions&gt;)
+- [NoContentResultAssertions](Atc.Rest.FluentAssertions.md#nocontentresultassertions)
 - [NotFoundResultAssertions](Atc.Rest.FluentAssertions.md#notfoundresultassertions)
 - [OkResultAssertions](Atc.Rest.FluentAssertions.md#okresultassertions)
 - [ResultAssertions](Atc.Rest.FluentAssertions.md#resultassertions)

--- a/docs/CodeDoc/Atc.Rest.FluentAssertions/IndexExtended.md
+++ b/docs/CodeDoc/Atc.Rest.FluentAssertions/IndexExtended.md
@@ -13,15 +13,25 @@
 
 ## [Atc.Rest.FluentAssertions](Atc.Rest.FluentAssertions.md)
 
-- [NotFoundResultAssertions](Atc.Rest.FluentAssertions.md#notfoundresultassertions)
+- [AcceptedResultAssertions](Atc.Rest.FluentAssertions.md#acceptedresultassertions)
+- [BadRequestResultAssertions](Atc.Rest.FluentAssertions.md#badrequestresultassertions)
+- [ContentResultAssertions&lt;TAssertions&gt;](Atc.Rest.FluentAssertions.md#contentresultassertions&lt;tassertions&gt;)
   -  Methods
      - WithContent(T expectedContent, string because = , object[] becauseArgs)
+- [ErrorContentResultAssertions&lt;TAssertions&gt;](Atc.Rest.FluentAssertions.md#errorcontentresultassertions&lt;tassertions&gt;)
+  -  Methods
      - WithErrorMessage(string expectedErrorMessage, string because = , object[] becauseArgs)
+- [NoContentResultAssertions](Atc.Rest.FluentAssertions.md#nocontentresultassertions)
+- [NotFoundResultAssertions](Atc.Rest.FluentAssertions.md#notfoundresultassertions)
 - [OkResultAssertions](Atc.Rest.FluentAssertions.md#okresultassertions)
   -  Methods
      - WithContent(T expectedContent, string because = , object[] becauseArgs)
+     - WithContentOfType(string because = , object[] becauseArgs)
 - [ResultAssertions](Atc.Rest.FluentAssertions.md#resultassertions)
   -  Methods
+     - BeAcceptedResult(string because = , object[] becauseArgs)
+     - BeBadRequestResult(string because = , object[] becauseArgs)
+     - BeNoContentResult(string because = , object[] becauseArgs)
      - BeNotFoundResult(string because = , object[] becauseArgs)
      - BeOkResult(string because = , object[] becauseArgs)
 - [ResultBaseExtensions](Atc.Rest.FluentAssertions.md#resultbaseextensions)

--- a/docs/CodeDoc/Atc/Atc.Helpers.md
+++ b/docs/CodeDoc/Atc/Atc.Helpers.md
@@ -207,7 +207,7 @@ CardinalDirectionType GetWhenRotate180(CardinalDirectionType cardinalDirectionTy
 #### GetWhenRotateLeft
 
 ```csharp
-CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
+CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
 ```
 <p><b>Summary:</b> Gets the when rotate left.</p>
 
@@ -219,7 +219,7 @@ CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionT
 #### GetWhenRotateLeft
 
 ```csharp
-CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
+CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
 ```
 <p><b>Summary:</b> Gets the when rotate left.</p>
 
@@ -231,7 +231,7 @@ CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionT
 #### GetWhenRotateRight
 
 ```csharp
-CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
+CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
 ```
 <p><b>Summary:</b> Gets the when rotate right.</p>
 
@@ -243,7 +243,7 @@ CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirection
 #### GetWhenRotateRight
 
 ```csharp
-CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
+CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
 ```
 <p><b>Summary:</b> Gets the when rotate right.</p>
 

--- a/docs/CodeDoc/Atc/Atc.Helpers.md
+++ b/docs/CodeDoc/Atc/Atc.Helpers.md
@@ -207,7 +207,7 @@ CardinalDirectionType GetWhenRotate180(CardinalDirectionType cardinalDirectionTy
 #### GetWhenRotateLeft
 
 ```csharp
-CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
+CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
 ```
 <p><b>Summary:</b> Gets the when rotate left.</p>
 
@@ -219,7 +219,7 @@ CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionT
 #### GetWhenRotateLeft
 
 ```csharp
-CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
+CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
 ```
 <p><b>Summary:</b> Gets the when rotate left.</p>
 
@@ -231,7 +231,7 @@ CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionT
 #### GetWhenRotateRight
 
 ```csharp
-CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
+CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
 ```
 <p><b>Summary:</b> Gets the when rotate right.</p>
 
@@ -243,7 +243,7 @@ CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirection
 #### GetWhenRotateRight
 
 ```csharp
-CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
+CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
 ```
 <p><b>Summary:</b> Gets the when rotate right.</p>
 

--- a/src/Atc.Rest.FluentAssertions/Assertions/AcceptedResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/AcceptedResultAssertions.cs
@@ -1,0 +1,17 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable ConstantConditionalAccessQualifier
+// ReSharper disable once CheckNamespace
+namespace Atc.Rest.FluentAssertions
+{
+    public class AcceptedResultAssertions : ContentResultAssertions<AcceptedResultAssertions>
+    {
+        public AcceptedResultAssertions(ContentResult subject) : base(subject) { }
+
+        protected override string Identifier { get; } = "accepted result";
+
+        protected override AndWhichConstraint<AcceptedResultAssertions, ContentResult> CreateAndWhichConstraint()
+            => new AndWhichConstraint<AcceptedResultAssertions, ContentResult>(this, Subject);
+    }
+}

--- a/src/Atc.Rest.FluentAssertions/Assertions/BadRequestResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/BadRequestResultAssertions.cs
@@ -1,0 +1,17 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable ConstantConditionalAccessQualifier
+// ReSharper disable once CheckNamespace
+namespace Atc.Rest.FluentAssertions
+{
+    public class BadRequestResultAssertions : ErrorContentResultAssertions<BadRequestResultAssertions>
+    {
+        public BadRequestResultAssertions(ContentResult subject) : base(subject) { }
+
+        protected override string Identifier { get; } = "bad request result";
+
+        protected override AndWhichConstraint<BadRequestResultAssertions, ContentResult> CreateAndWhichConstraint()
+            => new AndWhichConstraint<BadRequestResultAssertions, ContentResult>(this, Subject);
+    }
+}

--- a/src/Atc.Rest.FluentAssertions/Assertions/ContentResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/ContentResultAssertions.cs
@@ -1,0 +1,41 @@
+﻿using System.Text.Json;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable ConstantConditionalAccessQualifier
+// ReSharper disable once CheckNamespace
+namespace Atc.Rest.FluentAssertions
+{
+    public abstract class ContentResultAssertions<TAssertions> : ReferenceTypeAssertions<ContentResult, ContentResultAssertions<TAssertions>>
+    {
+        protected ContentResultAssertions(ContentResult subject) : base(subject) { }
+
+        public AndWhichConstraint<TAssertions, ContentResult> WithContent<T>(T expectedContent, string because = "", params object[] becauseArgs)
+        {
+            using (new AssertionScope(Identifier))
+            {
+                Subject.ContentType.Should().Be("application/json");
+                var content = GetContentValueAs<T>();
+                content.Should().BeEquivalentTo(expectedContent, because, becauseArgs);
+            }
+
+            return CreateAndWhichConstraint();
+        }
+
+        protected abstract AndWhichConstraint<TAssertions, ContentResult> CreateAndWhichConstraint();
+
+        protected T GetContentValueAs<T>()
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<T>(Subject.Content);
+            }
+            catch (JsonException)
+            {
+                return Subject.Content.As<T>();
+            }
+        }
+    }
+}

--- a/src/Atc.Rest.FluentAssertions/Assertions/ErrorContentResultAssertions{TAssertions}.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/ErrorContentResultAssertions{TAssertions}.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable ConstantConditionalAccessQualifier
+// ReSharper disable once CheckNamespace
+namespace Atc.Rest.FluentAssertions
+{
+
+    public abstract class ErrorContentResultAssertions<TAssertions> : ContentResultAssertions<TAssertions>
+    {
+        protected ErrorContentResultAssertions(ContentResult subject) : base(subject) { }
+
+        public AndWhichConstraint<TAssertions, ContentResult> WithErrorMessage(string expectedErrorMessage, string because = "", params object[] becauseArgs)
+        {
+            using (new AssertionScope($"error message of \"{Identifier}\""))
+            {
+                var problemDetail = GetContentValueAs<ProblemDetails>()?.Detail ?? GetContentValueAs<string>();
+                problemDetail.Should().Be(expectedErrorMessage, because, becauseArgs);
+            }
+
+            return CreateAndWhichConstraint();
+        }
+    }
+}

--- a/src/Atc.Rest.FluentAssertions/Assertions/ErrorContentResultAssertions{TAssertions}.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/ErrorContentResultAssertions{TAssertions}.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 // ReSharper disable once CheckNamespace
 namespace Atc.Rest.FluentAssertions
 {
-
     public abstract class ErrorContentResultAssertions<TAssertions> : ContentResultAssertions<TAssertions>
     {
         protected ErrorContentResultAssertions(ContentResult subject) : base(subject) { }
@@ -15,8 +14,8 @@ namespace Atc.Rest.FluentAssertions
         {
             using (new AssertionScope($"error message of \"{Identifier}\""))
             {
-                var problemDetail = GetContentValueAs<ProblemDetails>()?.Detail ?? GetContentValueAs<string>();
-                problemDetail.Should().Be(expectedErrorMessage, because, becauseArgs);
+                var problemDetails = GetContentValueAs<ProblemDetails>()?.Detail ?? GetContentValueAs<string>();
+                problemDetails.Should().Be(expectedErrorMessage, because, becauseArgs);
             }
 
             return CreateAndWhichConstraint();

--- a/src/Atc.Rest.FluentAssertions/Assertions/NoContentResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/NoContentResultAssertions.cs
@@ -1,0 +1,17 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable ConstantConditionalAccessQualifier
+// ReSharper disable once CheckNamespace
+namespace Atc.Rest.FluentAssertions
+{
+    public class NoContentResultAssertions : ContentResultAssertions<NoContentResultAssertions>
+    {
+        public NoContentResultAssertions(ContentResult subject) : base(subject) { }
+
+        protected override string Identifier { get; } = "no content result";
+
+        protected override AndWhichConstraint<NoContentResultAssertions, ContentResult> CreateAndWhichConstraint()
+            => new AndWhichConstraint<NoContentResultAssertions, ContentResult>(this, Subject);
+    }
+}

--- a/src/Atc.Rest.FluentAssertions/Assertions/NotFoundResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/NotFoundResultAssertions.cs
@@ -1,57 +1,19 @@
 ﻿using System.Text.Json;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using FluentAssertions.Primitives;
 using Microsoft.AspNetCore.Mvc;
 
 // ReSharper disable ConstantConditionalAccessQualifier
 // ReSharper disable once CheckNamespace
 namespace Atc.Rest.FluentAssertions
 {
-    public class NotFoundResultAssertions : ReferenceTypeAssertions<ContentResult, NotFoundResultAssertions>
+    public class NotFoundResultAssertions : ErrorContentResultAssertions<NotFoundResultAssertions>
     {
-        private readonly ContentResult subject;
-
-        public NotFoundResultAssertions(ContentResult subject)
-        {
-            this.subject = subject;
-        }
+        public NotFoundResultAssertions(ContentResult subject) : base(subject) { }
 
         protected override string Identifier => "not found result";
 
-        public AndWhichConstraint<NotFoundResultAssertions, ContentResult> WithErrorMessage(string expectedErrorMessage, string because = "", params object[] becauseArgs)
-        {
-            using (new AssertionScope("error message of \"not found result\""))
-            {
-                var problemDetail = GetContentValueAs<ProblemDetails>()?.Detail ?? GetContentValueAs<string>();
-                problemDetail.Should().Be(expectedErrorMessage, because, becauseArgs);
-            }
-
-            return new AndWhichConstraint<NotFoundResultAssertions, ContentResult>(this, subject);
-        }
-
-        public AndWhichConstraint<NotFoundResultAssertions, ContentResult> WithContent<T>(T expectedContent, string because = "", params object[] becauseArgs)
-        {
-            using (new AssertionScope(Identifier))
-            {
-                subject.ContentType.Should().Be("application/json");
-                var content = GetContentValueAs<T>();
-                content.Should().BeEquivalentTo(expectedContent, because, becauseArgs);
-            }
-
-            return new AndWhichConstraint<NotFoundResultAssertions, ContentResult>(this, subject);
-        }
-
-        private T GetContentValueAs<T>()
-        {
-            try
-            {
-                return JsonSerializer.Deserialize<T>(subject.Content);
-            }
-            catch (JsonException)
-            {
-                return subject.Content.As<T>();
-            }
-        }
+        protected override AndWhichConstraint<NotFoundResultAssertions, ContentResult> CreateAndWhichConstraint()
+            => new AndWhichConstraint<NotFoundResultAssertions, ContentResult>(this, Subject);
     }
 }

--- a/src/Atc.Rest.FluentAssertions/Assertions/OkResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/OkResultAssertions.cs
@@ -8,29 +8,25 @@ namespace Atc.Rest.FluentAssertions
 {
     public class OkResultAssertions : ReferenceTypeAssertions<OkObjectResult, OkResultAssertions>
     {
-        private readonly OkObjectResult subject;
-
-        public OkResultAssertions(OkObjectResult subject)
-        {
-            this.subject = subject;
-        }
-
         protected override string Identifier => "OK result";
+
+        public OkResultAssertions(OkObjectResult subject) : base(subject) { }
+
+        public AndWhichConstraint<ObjectAssertions, T> WithContentOfType<T>(string because = "", params object[] becauseArgs)
+            => Subject.Value.Should().BeOfType<T>(because, becauseArgs);
 
         public AndWhichConstraint<OkResultAssertions, OkObjectResult> WithContent<T>(T expectedContent, string because = "", params object[] becauseArgs)
         {
-            using (new AssertionScope(Identifier))
+            using (new AssertionScope($"{Identifier} value"))
             {
-                subject.Value
-                    .Should()
-                    .BeOfType<T>()
+                WithContentOfType<T>(because, becauseArgs)
                     .And
                     .Subject
                     .Should()
                     .BeEquivalentTo(expectedContent, because, becauseArgs);
-            }
 
-            return new AndWhichConstraint<OkResultAssertions, OkObjectResult>(this, subject);
+                return new AndWhichConstraint<OkResultAssertions, OkObjectResult>(this, Subject);
+            }
         }
     }
 }

--- a/src/Atc.Rest.FluentAssertions/Assertions/ResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/ResultAssertions.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions.Execution;
+﻿using System.Net;
+using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -18,40 +19,40 @@ namespace Atc.Rest.FluentAssertions
 
         public OkResultAssertions BeOkResult(string because = "", params object[] becauseArgs)
         {
-            AssertIsResultTypeWithStatusCode<OkObjectResult>(200, because, becauseArgs);
+            AssertIsResultTypeWithStatusCode<OkObjectResult>(HttpStatusCode.OK, because, becauseArgs);
             var okSubject = (OkObjectResult)subject;
             return new OkResultAssertions(okSubject);
         }
 
         public AcceptedResultAssertions BeAcceptedResult(string because = "", params object[] becauseArgs)
         {
-            AssertIsResultTypeWithStatusCode<ContentResult>(202, because, becauseArgs);
+            AssertIsResultTypeWithStatusCode<ContentResult>(HttpStatusCode.Accepted, because, becauseArgs);
             var okSubject = (ContentResult)subject;
             return new AcceptedResultAssertions(okSubject);
         }
 
         public NoContentResultAssertions BeNoContentResult(string because = "", params object[] becauseArgs)
         {
-            AssertIsResultTypeWithStatusCode<ContentResult>(204, because, becauseArgs);
+            AssertIsResultTypeWithStatusCode<ContentResult>(HttpStatusCode.NoContent, because, becauseArgs);
             var okSubject = (ContentResult)subject;
             return new NoContentResultAssertions(okSubject);
         }
 
         public BadRequestResultAssertions BeBadRequestResult(string because = "", params object[] becauseArgs)
         {
-            AssertIsResultTypeWithStatusCode<ContentResult>(400, because, becauseArgs);
+            AssertIsResultTypeWithStatusCode<ContentResult>(HttpStatusCode.BadRequest, because, becauseArgs);
             var okSubject = (ContentResult)subject;
             return new BadRequestResultAssertions(okSubject);
         }
 
         public NotFoundResultAssertions BeNotFoundResult(string because = "", params object[] becauseArgs)
         {
-            AssertIsResultTypeWithStatusCode<ContentResult>(404, because, becauseArgs);
+            AssertIsResultTypeWithStatusCode<ContentResult>(HttpStatusCode.NotFound, because, becauseArgs);
             var notFoundSubject = (ContentResult)subject;
             return new NotFoundResultAssertions(notFoundSubject);
         }
 
-        private void AssertIsResultTypeWithStatusCode<T>(int expectedStatusCode, string because, object[] becauseArgs) where T : class, IStatusCodeActionResult
+        private void AssertIsResultTypeWithStatusCode<T>(HttpStatusCode expectedStatusCode, string because, object[] becauseArgs) where T : class, IStatusCodeActionResult
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -60,8 +61,8 @@ namespace Atc.Rest.FluentAssertions
                 .FailWith("Expected {context:result} to be of type {0}{reason}, but found {1}.", _ => typeof(T), x => subject.GetType())
                 .Then
                 .Given(x => x?.StatusCode)
-                .ForCondition(x => x == expectedStatusCode)
-                .FailWith("Expected status code from {context:result} to be {0}{reason}, but found {1}.", _ => expectedStatusCode, x => x);
+                .ForCondition(x => x == (int)expectedStatusCode)
+                .FailWith("Expected status code from {context:result} to be {0}{reason}, but found {1}.", _ => (int)expectedStatusCode, x => x);
         }
     }
 }

--- a/src/Atc.Rest.FluentAssertions/Assertions/ResultAssertions.cs
+++ b/src/Atc.Rest.FluentAssertions/Assertions/ResultAssertions.cs
@@ -23,6 +23,27 @@ namespace Atc.Rest.FluentAssertions
             return new OkResultAssertions(okSubject);
         }
 
+        public AcceptedResultAssertions BeAcceptedResult(string because = "", params object[] becauseArgs)
+        {
+            AssertIsResultTypeWithStatusCode<ContentResult>(202, because, becauseArgs);
+            var okSubject = (ContentResult)subject;
+            return new AcceptedResultAssertions(okSubject);
+        }
+
+        public NoContentResultAssertions BeNoContentResult(string because = "", params object[] becauseArgs)
+        {
+            AssertIsResultTypeWithStatusCode<ContentResult>(204, because, becauseArgs);
+            var okSubject = (ContentResult)subject;
+            return new NoContentResultAssertions(okSubject);
+        }
+
+        public BadRequestResultAssertions BeBadRequestResult(string because = "", params object[] becauseArgs)
+        {
+            AssertIsResultTypeWithStatusCode<ContentResult>(400, because, becauseArgs);
+            var okSubject = (ContentResult)subject;
+            return new BadRequestResultAssertions(okSubject);
+        }
+
         public NotFoundResultAssertions BeNotFoundResult(string because = "", params object[] becauseArgs)
         {
             AssertIsResultTypeWithStatusCode<ContentResult>(404, because, becauseArgs);

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/AcceptedResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/AcceptedResultAssertionsTests.cs
@@ -10,10 +10,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
+            // Arrange
             var expected = new ContentResult();
 
+            // Act
             var sut = new AcceptedResultAssertions(expected);
 
+            // Assert
             sut.Subject.Should().Be(expected);
         }
 

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/AcceptedResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/AcceptedResultAssertionsTests.cs
@@ -1,19 +1,18 @@
-﻿using Atc.Rest.FluentAssertions.Tests.XUnitTestData;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 using Xunit.Sdk;
 
 namespace Atc.Rest.FluentAssertions.Tests.Assertions
 {
-    public class NotFoundResultAssertionsTests
+    public class AcceptedResultAssertionsTests
     {
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
             var expected = new ContentResult();
 
-            var sut = new NotFoundResultAssertions(expected);
+            var sut = new AcceptedResultAssertions(expected);
 
             sut.Subject.Should().Be(expected);
         }
@@ -28,13 +27,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new AcceptedResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("BAR"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected accepted result to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Fact]
@@ -47,13 +46,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new AcceptedResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("BAR", "Because of something"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected accepted result to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Fact]
@@ -66,13 +65,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "BAZ",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new AcceptedResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("FOO"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""application/json"" with a length of 16, but ""BAZ"" has a length of 3, differs near ""BAZ"" (index 0).");
+                .WithMessage(@"Expected accepted result to be ""application/json"" with a length of 16, but ""BAZ"" has a length of 3, differs near ""BAZ"" (index 0).");
         }
 
         [Fact]
@@ -85,39 +84,10 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new AcceptedResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("FOO"))
-                .Should()
-                .NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(TestDataAssertions.ErrorMessageContent), MemberType = typeof(TestDataAssertions))]
-        public void WithErrorMessage_Throws_When_Content_Doenst_Match_Expected(string content)
-        {
-            // Arrange
-            var target = new ContentResult { Content = content };
-            var sut = new NotFoundResultAssertions(target);
-
-            // Act & Assert
-            sut.Invoking(x => x.WithErrorMessage("BAR"))
-                .Should()
-                .Throw<XunitException>()
-                .WithMessage(@"Expected error message of ""not found result"" to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
-        }
-
-        [Theory]
-        [MemberData(nameof(TestDataAssertions.ErrorMessageContent), MemberType = typeof(TestDataAssertions))]
-        public void WithErrorMessage_Does_Not_Throw_When_Expected_Match(string content)
-        {
-            // Arrange
-            var target = new ContentResult { Content = content };
-            var sut = new NotFoundResultAssertions(target);
-
-            // Act & Assert
-            sut.Invoking(x => x.WithErrorMessage("FOO"))
                 .Should()
                 .NotThrow();
         }

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/BadRequestResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/BadRequestResultAssertionsTests.cs
@@ -6,14 +6,14 @@ using Xunit.Sdk;
 
 namespace Atc.Rest.FluentAssertions.Tests.Assertions
 {
-    public class NotFoundResultAssertionsTests
+    public class BadRequestResultAssertionsTests
     {
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
             var expected = new ContentResult();
 
-            var sut = new NotFoundResultAssertions(expected);
+            var sut = new BadRequestResultAssertions(expected);
 
             sut.Subject.Should().Be(expected);
         }
@@ -28,13 +28,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new BadRequestResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("BAR"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected bad request result to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Fact]
@@ -47,13 +47,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new BadRequestResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("BAR", "Because of something"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected bad request result to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Fact]
@@ -66,13 +66,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "BAZ",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new BadRequestResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("FOO"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""application/json"" with a length of 16, but ""BAZ"" has a length of 3, differs near ""BAZ"" (index 0).");
+                .WithMessage(@"Expected bad request result to be ""application/json"" with a length of 16, but ""BAZ"" has a length of 3, differs near ""BAZ"" (index 0).");
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new BadRequestResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("FOO"))
@@ -99,13 +99,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         {
             // Arrange
             var target = new ContentResult { Content = content };
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new BadRequestResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithErrorMessage("BAR"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected error message of ""not found result"" to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected error message of ""bad request result"" to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Theory]
@@ -114,7 +114,7 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         {
             // Arrange
             var target = new ContentResult { Content = content };
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new BadRequestResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithErrorMessage("FOO"))

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/BadRequestResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/BadRequestResultAssertionsTests.cs
@@ -11,10 +11,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
+            // Arrange
             var expected = new ContentResult();
 
+            // Act
             var sut = new BadRequestResultAssertions(expected);
 
+            // Assert
             sut.Subject.Should().Be(expected);
         }
 

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/NoContentResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/NoContentResultAssertionsTests.cs
@@ -10,10 +10,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
+            // Arrange
             var expected = new ContentResult();
 
+            // Act
             var sut = new NoContentResultAssertions(expected);
 
+            // Assert
             sut.Subject.Should().Be(expected);
         }
 

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/NoContentResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/NoContentResultAssertionsTests.cs
@@ -1,19 +1,18 @@
-﻿using Atc.Rest.FluentAssertions.Tests.XUnitTestData;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 using Xunit.Sdk;
 
 namespace Atc.Rest.FluentAssertions.Tests.Assertions
 {
-    public class NotFoundResultAssertionsTests
+    public class NoContentResultAssertionsTests
     {
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
             var expected = new ContentResult();
 
-            var sut = new NotFoundResultAssertions(expected);
+            var sut = new NoContentResultAssertions(expected);
 
             sut.Subject.Should().Be(expected);
         }
@@ -28,13 +27,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new NoContentResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("BAR"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected no content result to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Fact]
@@ -47,13 +46,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new NoContentResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("BAR", "Because of something"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected no content result to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Fact]
@@ -66,13 +65,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "BAZ",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new NoContentResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("FOO"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected not found result to be ""application/json"" with a length of 16, but ""BAZ"" has a length of 3, differs near ""BAZ"" (index 0).");
+                .WithMessage(@"Expected no content result to be ""application/json"" with a length of 16, but ""BAZ"" has a length of 3, differs near ""BAZ"" (index 0).");
         }
 
         [Fact]
@@ -85,39 +84,10 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
                 ContentType = "application/json",
             };
 
-            var sut = new NotFoundResultAssertions(target);
+            var sut = new NoContentResultAssertions(target);
 
             // Act & Assert
             sut.Invoking(x => x.WithContent("FOO"))
-                .Should()
-                .NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(TestDataAssertions.ErrorMessageContent), MemberType = typeof(TestDataAssertions))]
-        public void WithErrorMessage_Throws_When_Content_Doenst_Match_Expected(string content)
-        {
-            // Arrange
-            var target = new ContentResult { Content = content };
-            var sut = new NotFoundResultAssertions(target);
-
-            // Act & Assert
-            sut.Invoking(x => x.WithErrorMessage("BAR"))
-                .Should()
-                .Throw<XunitException>()
-                .WithMessage(@"Expected error message of ""not found result"" to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
-        }
-
-        [Theory]
-        [MemberData(nameof(TestDataAssertions.ErrorMessageContent), MemberType = typeof(TestDataAssertions))]
-        public void WithErrorMessage_Does_Not_Throw_When_Expected_Match(string content)
-        {
-            // Arrange
-            var target = new ContentResult { Content = content };
-            var sut = new NotFoundResultAssertions(target);
-
-            // Act & Assert
-            sut.Invoking(x => x.WithErrorMessage("FOO"))
                 .Should()
                 .NotThrow();
         }

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/NotFoundResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/NotFoundResultAssertionsTests.cs
@@ -11,10 +11,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
+            // Arrange
             var expected = new ContentResult();
 
+            // Act
             var sut = new NotFoundResultAssertions(expected);
 
+            // Assert
             sut.Subject.Should().Be(expected);
         }
 

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/OkResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/OkResultAssertionsTests.cs
@@ -11,10 +11,13 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         [Fact]
         public void Ctor_Sets_Subject_On_Subject_Property()
         {
+            // Arrange
             var expected = new OkObjectResult("FOO");
 
+            // Act
             var sut = new OkResultAssertions(expected);
 
+            // Assert
             sut.Subject.Should().Be(expected);
         }
 

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/OkResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/OkResultAssertionsTests.cs
@@ -9,6 +9,16 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
     public class OkResultAssertionsTests
     {
         [Fact]
+        public void Ctor_Sets_Subject_On_Subject_Property()
+        {
+            var expected = new OkObjectResult("FOO");
+
+            var sut = new OkResultAssertions(expected);
+
+            sut.Subject.Should().Be(expected);
+        }
+
+        [Fact]
         public void WithContent_Throws_When_Content_Is_Not_Equivalent_To_Expected()
         {
             // Arrange
@@ -20,7 +30,7 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
             sut.Invoking(x => x.WithContent("BAR"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected OK result to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected OK result value to be ""BAR"", but ""FOO"" differs near ""FOO"" (index 0).");
         }
 
         [Fact]
@@ -35,7 +45,21 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
             sut.Invoking(x => x.WithContent("BAR", "Because of something"))
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage(@"Expected OK result to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
+                .WithMessage(@"Expected OK result value to be ""BAR"" Because of something, but ""FOO"" differs near ""FOO"" (index 0).");
+        }
+
+        [Fact]
+        public void WithContentOfType_Throws_When_Content_Is_Not_Expected_Type_With_BecauseMessage()
+        {
+            // Arrange
+            var target = new OkObjectResult("FOO");
+            var sut = new OkResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.WithContentOfType<int>("Because of something"))
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage(@"Expected type to be System.Int32 Because of something, but found System.String.");
         }
 
         [Fact]

--- a/test/Atc.Rest.FluentAssertions.Tests/Assertions/ResultAssertionsTests.cs
+++ b/test/Atc.Rest.FluentAssertions.Tests/Assertions/ResultAssertionsTests.cs
@@ -51,6 +51,129 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         }
 
         [Fact]
+        public void BeAcceptedResult_Throws_When_Subject_Isnt_ContentResult()
+        {
+            // Arrange
+            var target = new DummyResult();
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeAcceptedResult())
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage($"Expected result to be of type Microsoft.AspNetCore.Mvc.ContentResult, but found {target.GetType().FullName}.");
+        }
+
+        [Fact]
+        public void BeAcceptedResult_Throws_When_ContentResult_StatusCode_Isnt_202()
+        {
+            // Arrange
+            var target = new ContentResult { StatusCode = 1337 };
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeAcceptedResult())
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage($"Expected status code from result to be 202, but found {target.StatusCode}.");
+        }
+
+        [Fact]
+        public void BeAcceptedResult_Passes_When_Subject_Is_ContentResult_With_StatusCode_202()
+        {
+            // Arrange
+            var target = new ContentResult { StatusCode = 202 };
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeAcceptedResult())
+                .Should()
+                .NotThrow();
+        }
+
+        [Fact]
+        public void BeNoContentResult_Throws_When_Subject_Isnt_ContentResult()
+        {
+            // Arrange
+            var target = new DummyResult();
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeNoContentResult())
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage($"Expected result to be of type Microsoft.AspNetCore.Mvc.ContentResult, but found {target.GetType().FullName}.");
+        }
+
+        [Fact]
+        public void BeNoContentResult_Throws_When_ContentResult_StatusCode_Isnt_204()
+        {
+            // Arrange
+            var target = new ContentResult { StatusCode = 1337 };
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeNoContentResult())
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage($"Expected status code from result to be 204, but found {target.StatusCode}.");
+        }
+
+        [Fact]
+        public void BeNoContentResult_Passes_When_Subject_Is_ContentResult_With_StatusCode_204()
+        {
+            // Arrange
+            var target = new ContentResult { StatusCode = 204 };
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeNoContentResult())
+                .Should()
+                .NotThrow();
+        }
+
+        [Fact]
+        public void BeBadRequestResult_Throws_When_Subject_Isnt_ContentResult()
+        {
+            // Arrange
+            var target = new DummyResult();
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeBadRequestResult())
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage($"Expected result to be of type Microsoft.AspNetCore.Mvc.ContentResult, but found {target.GetType().FullName}.");
+        }
+
+        [Fact]
+        public void BeBadRequestResult_Throws_When_ContentResult_StatusCode_Isnt_400()
+        {
+            // Arrange
+            var target = new ContentResult { StatusCode = 1337 };
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeBadRequestResult())
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage($"Expected status code from result to be 400, but found {target.StatusCode}.");
+        }
+
+        [Fact]
+        public void BeBadRequestResult_Passes_When_Subject_Is_ContentResult_With_StatusCode_400()
+        {
+            // Arrange
+            var target = new ContentResult { StatusCode = 400 };
+            var sut = new ResultAssertions(target);
+
+            // Act & Assert
+            sut.Invoking(x => x.BeBadRequestResult())
+                .Should()
+                .NotThrow();
+        }
+
+        [Fact]
         public void BeNotFoundResult_Throws_When_Subject_Isnt_ContentResult()
         {
             // Arrange
@@ -68,7 +191,7 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         public void BeNotFoundResult_Throws_When_ContentResult_StatusCode_Isnt_404()
         {
             // Arrange
-            var target = new ContentResult { StatusCode = 400 };
+            var target = new ContentResult { StatusCode = 1337 };
             var sut = new ResultAssertions(target);
 
             // Act & Assert
@@ -79,7 +202,7 @@ namespace Atc.Rest.FluentAssertions.Tests.Assertions
         }
 
         [Fact]
-        public void BeNotFoundResult_Passes_When_Subject_Is_OkObjectResult_With_StatusCode_200()
+        public void BeNotFoundResult_Passes_When_Subject_Is_ContentResult_With_StatusCode_404()
         {
             // Arrange
             var target = new ContentResult { StatusCode = 404 };


### PR DESCRIPTION
Added the following assertion helpers:

- Should().BeAcceptedResult()
- Should().BeNoContentResult()
- Should().BeBadContentResult()

Tweaked existing assertion helpers to make the result subject available through the Subject property.

Added an additional WithContentOfType to OkResultAssertion to make it easier to assert against individual properties of the result type.