### PR TITLE
Updated Pagination's input and output type to accept different types of input

### DIFF
--- a/docs/CodeDoc/Atc/Atc.Helpers.md
+++ b/docs/CodeDoc/Atc/Atc.Helpers.md
@@ -443,6 +443,13 @@ List<Culture> GetCultures(List<string> includeOnlyCultureNames)
 #### GetCultures
 
 ```csharp
+List<Culture> GetCultures(int displayLanguageLcid)
+```
+<p><b>Summary:</b> Gets cultures.</p>
+
+#### GetCultures
+
+```csharp
 List<Culture> GetCultures(int displayLanguageLcid, List<int> includeOnlyLcids)
 ```
 <p><b>Summary:</b> Gets cultures.</p>
@@ -451,13 +458,6 @@ List<Culture> GetCultures(int displayLanguageLcid, List<int> includeOnlyLcids)
 
 ```csharp
 List<Culture> GetCultures(int displayLanguageLcid, List<string> includeOnlyCultureNames)
-```
-<p><b>Summary:</b> Gets cultures.</p>
-
-#### GetCultures
-
-```csharp
-List<Culture> GetCultures(int displayLanguageLcid)
 ```
 <p><b>Summary:</b> Gets cultures.</p>
 

--- a/docs/CodeDoc/Atc/Atc.Helpers.md
+++ b/docs/CodeDoc/Atc/Atc.Helpers.md
@@ -207,7 +207,7 @@ CardinalDirectionType GetWhenRotate180(CardinalDirectionType cardinalDirectionTy
 #### GetWhenRotateLeft
 
 ```csharp
-CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
+CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
 ```
 <p><b>Summary:</b> Gets the when rotate left.</p>
 
@@ -219,7 +219,7 @@ CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionT
 #### GetWhenRotateLeft
 
 ```csharp
-CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
+CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
 ```
 <p><b>Summary:</b> Gets the when rotate left.</p>
 
@@ -231,7 +231,7 @@ CardinalDirectionType GetWhenRotateLeft(CardinalDirectionType cardinalDirectionT
 #### GetWhenRotateRight
 
 ```csharp
-CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
+CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
 ```
 <p><b>Summary:</b> Gets the when rotate right.</p>
 
@@ -243,7 +243,7 @@ CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirection
 #### GetWhenRotateRight
 
 ```csharp
-CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
+CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType, int rotationNumber)
 ```
 <p><b>Summary:</b> Gets the when rotate right.</p>
 
@@ -443,13 +443,6 @@ List<Culture> GetCultures(List<string> includeOnlyCultureNames)
 #### GetCultures
 
 ```csharp
-List<Culture> GetCultures(int displayLanguageLcid)
-```
-<p><b>Summary:</b> Gets cultures.</p>
-
-#### GetCultures
-
-```csharp
 List<Culture> GetCultures(int displayLanguageLcid, List<int> includeOnlyLcids)
 ```
 <p><b>Summary:</b> Gets cultures.</p>
@@ -458,6 +451,13 @@ List<Culture> GetCultures(int displayLanguageLcid, List<int> includeOnlyLcids)
 
 ```csharp
 List<Culture> GetCultures(int displayLanguageLcid, List<string> includeOnlyCultureNames)
+```
+<p><b>Summary:</b> Gets cultures.</p>
+
+#### GetCultures
+
+```csharp
+List<Culture> GetCultures(int displayLanguageLcid)
 ```
 <p><b>Summary:</b> Gets cultures.</p>
 

--- a/src/Atc.Rest/Results/Pagination.cs
+++ b/src/Atc.Rest/Results/Pagination.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace Atc.Rest.Results
 {
+    [Serializable]
     public class Pagination<T>
     {
         public Pagination()
@@ -22,7 +23,6 @@ namespace Atc.Rest.Results
             QueryString = queryString;
             PageIndex = pageIndex;
             TotalCount = totalCount;
-            TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
         }
 
         public Pagination(IEnumerable<T> items, int pageSize, string? queryString, string? continuationToken)
@@ -50,13 +50,13 @@ namespace Atc.Rest.Results
 
         public int? TotalCount { get; set; }
 
-        public int? TotalPages { get; set; }
+        public int? TotalPages => TotalCount is null
+            ? null
+            : (int)Math.Ceiling((double)(TotalCount / PageSize));
 
-        public IReadOnlyCollection<T> Items { get; set; } = Array.Empty<T>();
+        public IReadOnlyList<T>? Items { get; set; } = Array.Empty<T>();
 
         public override string ToString()
-        {
-            return $"{nameof(Items)}.Count: {Items.Count}, {nameof(PageSize)}: {PageSize}, {nameof(PageIndex)}: {PageIndex}, {nameof(QueryString)}: {QueryString}, , {nameof(ContinuationToken)}: {ContinuationToken}, {nameof(TotalCount)}: {TotalCount}, {nameof(TotalPages)}: {TotalPages}";
-        }
+            => FormattableString.Invariant($"{nameof(PageIndex)}: {PageIndex}, {nameof(PageSize)}: {PageSize}, {nameof(QueryString)}: {QueryString}, {nameof(ContinuationToken)}: {ContinuationToken}, {nameof(Count)}: {Count}, {nameof(TotalCount)}: {TotalCount}, {nameof(TotalPages)}: {TotalPages}");
     }
 }

--- a/src/Atc.Rest/Results/Pagination.cs
+++ b/src/Atc.Rest/Results/Pagination.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Atc.Rest.Results
@@ -10,7 +10,7 @@ namespace Atc.Rest.Results
             // Dummy for serialization.
         }
 
-        public Pagination(List<T> items, int pageSize, string? queryString, int pageIndex, int totalCount)
+        public Pagination(IEnumerable<T> items, int pageSize, string? queryString, int pageIndex, int totalCount)
         {
             if (items is null)
             {
@@ -25,7 +25,7 @@ namespace Atc.Rest.Results
             TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
         }
 
-        public Pagination(List<T> items, int pageSize, string? queryString, string? continuationToken)
+        public Pagination(IEnumerable<T> items, int pageSize, string? queryString, string? continuationToken)
         {
             if (items is null)
             {
@@ -52,7 +52,7 @@ namespace Atc.Rest.Results
 
         public int? TotalPages { get; set; }
 
-        public List<T> Items { get; set; } = new List<T>();
+        public IReadOnlyCollection<T> Items { get; set; } = Array.Empty<T>();
 
         public override string ToString()
         {

--- a/test/Atc.Rest.Tests/Atc.Rest.Tests.csproj
+++ b/test/Atc.Rest.Tests/Atc.Rest.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />

--- a/test/Atc.Rest.Tests/Results/PaginationTests.cs
+++ b/test/Atc.Rest.Tests/Results/PaginationTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using Atc.Rest.Results;
+using AutoFixture;
+using FluentAssertions;
+using Xunit;
+
+namespace Atc.Rest.Tests.Results
+{
+    public class PaginationTests
+    {
+        private Fixture Fixture { get; } = new Fixture();
+
+        [Fact]
+        public void Ctor_Copies_Items_To_Pagination()
+        {
+            // Arrange
+            var data = Fixture.Create<List<string>>();
+            var sut = new Pagination<string>(data, 5, null, null);
+
+            // Act
+            data.Add(Fixture.Create<string>());
+
+            // Assert
+            sut.Count.Should().Be(data.Count - 1);
+            sut.Items.Should().NotContain(data.Last());
+        }
+    }
+}


### PR DESCRIPTION
Since we create a copy of the items passed to Pagination anyway, we might as well allow users to pass in any type that implements `IEnumerable<T>`.

This will make the Pagination type more versatile for users, who might not have a List<T> as the source for the data they are sending to the clients.

The Items property is changed to a `IReadOnlyCollection `since the receiver will not need to add any more items to the collection.