### PR TITLE
Fix issue where Server Exceptions are not Shown in Application Insights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 /src/Atc.Rest.ApiGenerator.CLI/Properties/launchSettings.json
+.idea

--- a/src/Atc.Rest/Extensions/ServiceCollection/RestApiExtensions.cs
+++ b/src/Atc.Rest/Extensions/ServiceCollection/RestApiExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -60,12 +60,16 @@ namespace Microsoft.Extensions.DependencyInjection
 
             HandleAssemblyPairs(services, restApiOptions);
 
+            if (restApiOptions.ErrorHandlingExceptionFilter.Enable)
+            {
+                services.AddSingleton<ErrorHandlingExceptionFilterAttribute>();
+            }
+
             var mvc = services
                 .AddControllers(mvcOptions =>
                 {
                     if (restApiOptions.ErrorHandlingExceptionFilter.Enable)
                     {
-                        services.AddSingleton<ErrorHandlingExceptionFilterAttribute>();
                         mvcOptions.Filters.AddService<ErrorHandlingExceptionFilterAttribute>();
                     }
 

--- a/src/Atc.Rest/Extensions/ServiceCollection/RestApiExtensions.cs
+++ b/src/Atc.Rest/Extensions/ServiceCollection/RestApiExtensions.cs
@@ -65,10 +65,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     if (restApiOptions.ErrorHandlingExceptionFilter.Enable)
                     {
-                        mvcOptions.Filters.Add(
-                            new ErrorHandlingExceptionFilterAttribute(
-                                restApiOptions.ErrorHandlingExceptionFilter.IncludeExceptionDetails,
-                                restApiOptions.ErrorHandlingExceptionFilter.UseProblemDetailsAsResponseBody));
+                        services.AddSingleton<ErrorHandlingExceptionFilterAttribute>();
+                        mvcOptions.Filters.AddService<ErrorHandlingExceptionFilterAttribute>();
                     }
 
                     mvcOptions.OutputFormatters.RemoveType<StringOutputFormatter>();

--- a/src/Atc.Rest/Filters/ErrorHandlingExceptionFilterAttribute.cs
+++ b/src/Atc.Rest/Filters/ErrorHandlingExceptionFilterAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Net.Mime;
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             RestApiOptions options)
         {
             this.telemetryClient = telemetryClient;
-            this.includeException = options.ErrorHandlingExceptionFilter.IncludeExceptionDetails;
-            this.useProblemDetailsAsResponseBody = options.ErrorHandlingExceptionFilter.UseProblemDetailsAsResponseBody;
+            includeException = options.ErrorHandlingExceptionFilter.IncludeExceptionDetails;
+            useProblemDetailsAsResponseBody = options.ErrorHandlingExceptionFilter.UseProblemDetailsAsResponseBody;
         }
 
         public override void OnException(ExceptionContext context)

--- a/src/Atc.Rest/Filters/ErrorHandlingExceptionFilterAttribute.cs
+++ b/src/Atc.Rest/Filters/ErrorHandlingExceptionFilterAttribute.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             var statusCode = GetHttpStatusCodeByExceptionType(context);
             var title = ensurePascalCaseAndSpacesBetweenWordsRegex.Replace(statusCode.ToString(), " $1");
 
-            return new ProblemDetails {Status = (int)statusCode, Title = title, Detail = CreateMessage(context),};
+            return new ProblemDetails { Status = (int)statusCode, Title = title, Detail = CreateMessage(context) };
         }
     }
 }


### PR DESCRIPTION
This pull request adds some missing functionality to `ErrorHandlingExceptionFilterAttribute` so that it uses the `TelemetryClient` to track exceptions after setting `ExceptionHandled` to `true` in the `ExceptionContext`

This resolves #119 