### PR TITLE
Add MathEx fixes, unit tests and improved documentation

### DIFF
--- a/docs/CodeDoc/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.md
+++ b/docs/CodeDoc/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.md
@@ -224,7 +224,7 @@ public static class ResultBaseExtensions
 ```csharp
 ResultAssertions Should(this ResultBase subject)
 ```
-<p><b>Summary:</b> Returns an `Atc.Rest.FluentAssertions.ResultAssertions` object that can be used  to assert the current ``.</p>
+<p><b>Summary:</b> Returns an `Atc.Rest.FluentAssertions.ResultAssertions` object that can be used  to assert the current `subject`.</p>
 
 <b>Parameters</b>
 

--- a/docs/CodeDoc/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.md
+++ b/docs/CodeDoc/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.md
@@ -224,7 +224,7 @@ public static class ResultBaseExtensions
 ```csharp
 ResultAssertions Should(this ResultBase subject)
 ```
-<p><b>Summary:</b> Returns an `Atc.Rest.FluentAssertions.ResultAssertions` object that can be used  to assert the current `subject`.</p>
+<p><b>Summary:</b> Returns an `Atc.Rest.FluentAssertions.ResultAssertions` object that can be used to assert the current `subject`.</p>
 
 <b>Parameters</b>
 

--- a/docs/CodeDoc/Atc.Rest/Atc.Rest.Middleware.md
+++ b/docs/CodeDoc/Atc.Rest/Atc.Rest.Middleware.md
@@ -27,7 +27,7 @@ Task InvokeAsync(HttpContext context)
 
 
 ## KeepAliveMiddleware
-Middleware responsible for handling the App service keep alive ping on http://{host-endpoint}.  If not enabled the application insights will report a failed request as the goes to http and not https.
+Middleware responsible for handling the App service keep alive ping on http://{host-endpoint}. If not enabled the application insights will report a failed request as the goes to http and not https.
 
 
 ```csharp

--- a/docs/CodeDoc/Atc/Atc.Math.Geometry.CoordinateSystem.md
+++ b/docs/CodeDoc/Atc/Atc.Math.Geometry.CoordinateSystem.md
@@ -35,7 +35,7 @@ Point2D ComputeCoordinateFromPolar(double angle, double radius)
 ```csharp
 double DistanceBetweenTwoPoints(Point2D pointA, Point2D pointB)
 ```
-<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2).  d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
+<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2). d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
 
 <b>Parameters</b>
 
@@ -48,7 +48,7 @@ double DistanceBetweenTwoPoints(Point2D pointA, Point2D pointB)
 ```csharp
 double DistanceBetweenTwoPoints(Point3D pointA, Point3D pointB)
 ```
-<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2).  d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
+<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2). d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
 
 <b>Parameters</b>
 
@@ -61,7 +61,7 @@ double DistanceBetweenTwoPoints(Point3D pointA, Point3D pointB)
 ```csharp
 double DistanceBetweenTwoPoints(CartesianCoordinate coordinateA, CartesianCoordinate coordinateB)
 ```
-<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2).  d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
+<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2). d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
 
 <b>Parameters</b>
 
@@ -74,7 +74,7 @@ double DistanceBetweenTwoPoints(CartesianCoordinate coordinateA, CartesianCoordi
 ```csharp
 double DistanceBetweenTwoPoints(double x1, double y1, double x2, double y2)
 ```
-<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2).  d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
+<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2). d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
 
 <b>Parameters</b>
 
@@ -87,7 +87,7 @@ double DistanceBetweenTwoPoints(double x1, double y1, double x2, double y2)
 ```csharp
 double DistanceBetweenTwoPoints(double x1, double y1, double z1, double x2, double y2, double z2)
 ```
-<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2).  d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
+<p><b>Summary:</b> The Euclidean distance between two points of the plane with Cartesian coordinates (x1,y1) and (x2,y2). d = Sqrt((x2-x1)^2 + (y2-y1)^2)</p>
 
 <b>Parameters</b>
 

--- a/docs/CodeDoc/Atc/Atc.Math.md
+++ b/docs/CodeDoc/Atc/Atc.Math.md
@@ -79,7 +79,7 @@ Func<int, int> Floor(Func<int, int> f, int period)
 ```csharp
 IEnumerable<int> GetDivisorsLessThanOrEqual(int value, int max)
 ```
-<p><b>Summary:</b> Gets divisors for `` that is less than or equal to the specified `` value.</p>
+<p><b>Summary:</b> Gets divisors for `value` that is less than or equal to the specified `max` value.</p>
 
 <b>Parameters</b>
 

--- a/docs/CodeDoc/Atc/Atc.Math.md
+++ b/docs/CodeDoc/Atc/Atc.Math.md
@@ -112,7 +112,7 @@ double GreatestCommonDivisor(double v1, double v2)
 ```csharp
 int Hysteron(ref int state, int x, int width = 1, int height = 1)
 ```
-<p><b>Summary:</b> Associates the input with the result of an operator that takes the path of a loop,  and its next state depends on its past state.</p>
+<p><b>Summary:</b> Associates the input with the result of an operator that takes the path of a loop, and its next state depends on its past state.</p>
 
 <b>Parameters</b>
 

--- a/docs/CodeDoc/Atc/Atc.Math.md
+++ b/docs/CodeDoc/Atc/Atc.Math.md
@@ -79,12 +79,12 @@ Func<int, int> Floor(Func<int, int> f, int period)
 ```csharp
 IEnumerable<int> GetDivisorsLessThanOrEqual(int value, int max)
 ```
-<p><b>Summary:</b> Gets the divisors less than or equal.</p>
+<p><b>Summary:</b> Gets divisors for `` that is less than or equal to the specified `` value.</p>
 
 <b>Parameters</b>
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value.<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`max`&nbsp;&nbsp;-&nbsp;&nbsp;The maximum.<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value to get divisors of.<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`max`&nbsp;&nbsp;-&nbsp;&nbsp;The maximum divisor threshold.<br />
 #### GreatestCommonDivisor
 
 ```csharp

--- a/docs/CodeDoc/Atc/Atc.md
+++ b/docs/CodeDoc/Atc/Atc.md
@@ -20,15 +20,15 @@ public enum AddressType
 | Value | Name | Description | Summary | 
 | --- | --- | --- | --- | 
 | 0 | None | None | Default None. | 
-| 1 | Address | Address | The address indicates that the returned result is a precise geocode for which we have  location information accurate down to street address precision. - With floor and door, if specified. | 
-| 2 | AccessAddress | Access Address | The access address indicates that the returned result is a precise geocode for which we have  location information accurate down to street address precision. - No floor and door. | 
+| 1 | Address | Address | The address indicates that the returned result is a precise geocode for which we have location information accurate down to street address precision. - With floor and door, if specified. | 
+| 2 | AccessAddress | Access Address | The access address indicates that the returned result is a precise geocode for which we have location information accurate down to street address precision. - No floor and door. | 
 | 3 | AllRegularly | All Regularly | All regularly | 
 | 4 | PreliminaryAddress | Preliminary Address | The preliminary address - same as AccessAddress, but preliminary. | 
 | 8 | PreliminaryAccessAddress | Preliminary Access Address | The preliminary access address - same as Address, but preliminary. | 
 | 12 | AllPreliminary | All Preliminary | All preliminary | 
 | 15 | All | All | All | 
-| 16 | RangeInterpolated | Range Interpolated | The range interpolated indicates that the returned result reflects an approximation (usually on a road)  interpolated between two precise points (such as intersections).  Interpolated results are generally returned when rooftop geocodes are unavailable for a street address. | 
-| 32 | GeometricCenter | Geometric Center | The geometric center indicates that the returned result is the geometric center  of a result such as a polyline (for example, a street) or polygon (region). | 
+| 16 | RangeInterpolated | Range Interpolated | The range interpolated indicates that the returned result reflects an approximation (usually on a road) interpolated between two precise points (such as intersections). Interpolated results are generally returned when rooftop geocodes are unavailable for a street address. | 
+| 32 | GeometricCenter | Geometric Center | The geometric center indicates that the returned result is the geometric center of a result such as a polyline (for example, a street) or polygon (region). | 
 | 64 | Approximate | Approximate | The approximate indicates that the returned result is approximate. | 
 | 128 | Partial | Partial | The partial indicates that this not an full-validated-address, but a more approximate address - based on country and city. | 
 

--- a/docs/CodeDoc/Atc/IndexExtended.md
+++ b/docs/CodeDoc/Atc/IndexExtended.md
@@ -462,6 +462,7 @@
      - double DoubleEpsilon
   -  Static Methods
      - AreClose(this double value1, double value2)
+     - CountDecimalPoints(this double value)
      - CurrencyRounding(this double value)
      - CurrencyRounding(this double value, int digits)
      - CurrencyRoundingAsInteger(this double value)

--- a/docs/CodeDoc/Atc/System.md
+++ b/docs/CodeDoc/Atc/System.md
@@ -1166,7 +1166,7 @@ string GetValueBetweenLessAndGreaterThanCharsIfExist(this string value)
 ```csharp
 string Humanize(this string value)
 ```
-<p><b>Summary:</b> Humanizes (make more human-readable) an identifier-style string  in either camel case or snake case. For example, CamelCase will be converted to  Camel Case and Snake_Case will be converted to Snake Case.</p>
+<p><b>Summary:</b> Humanizes (make more human-readable) an identifier-style string in either camel case or snake case. For example, CamelCase will be converted to Camel Case and Snake_Case will be converted to Snake Case.</p>
 
 <b>Parameters</b>
 
@@ -1450,7 +1450,7 @@ Stream ToStreamFromBase64(this string base64Data)
 ```csharp
 string TrimExtended(this string value)
 ```
-<p><b>Summary:</b> TrimExtended removes all leading and trailing white-space.  and multi-space characters from the current System.String object.</p>
+<p><b>Summary:</b> TrimExtended removes all leading and trailing white-space. and multi-space characters from the current System.String object.</p>
 
 <b>Parameters</b>
 
@@ -1911,7 +1911,7 @@ public static class TaskExtensions
 ```csharp
 void StartAndWaitAllThrottled(this IEnumerable<Task> tasksToRun, int maxTasksToRunInParallel, CancellationToken cancellationToken = null)
 ```
-<p><b>Summary:</b> Starts the given tasks and waits for them to complete. This will run, at most, the specified number of tasks in parallel.  <para>NOTE: If one of the given tasks has already been started, an exception will be thrown.</para></p>
+<p><b>Summary:</b> Starts the given tasks and waits for them to complete. This will run, at most, the specified number of tasks in parallel. <para>NOTE: If one of the given tasks has already been started, an exception will be thrown.</para></p>
 
 <b>Parameters</b>
 
@@ -1923,7 +1923,7 @@ void StartAndWaitAllThrottled(this IEnumerable<Task> tasksToRun, int maxTasksToR
 ```csharp
 void StartAndWaitAllThrottled(this IEnumerable<Task> tasksToRun, int maxTasksToRunInParallel, int timeoutInMilliseconds, CancellationToken cancellationToken = null)
 ```
-<p><b>Summary:</b> Starts the given tasks and waits for them to complete. This will run, at most, the specified number of tasks in parallel.  <para>NOTE: If one of the given tasks has already been started, an exception will be thrown.</para></p>
+<p><b>Summary:</b> Starts the given tasks and waits for them to complete. This will run, at most, the specified number of tasks in parallel. <para>NOTE: If one of the given tasks has already been started, an exception will be thrown.</para></p>
 
 <b>Parameters</b>
 
@@ -2265,7 +2265,7 @@ public static class VersionExtensions
 ```csharp
 int CompareTo(this Version version, Version otherVersion, int significantParts)
 ```
-<p><b>Summary:</b> Is 'version' greater then the 'otherVersion', where the significantParts is the stop part.  Example significantParts=2, then only Major and Minor wil be taken into consideration.</p>
+<p><b>Summary:</b> Is 'version' greater then the 'otherVersion', where the significantParts is the stop part. Example significantParts=2, then only Major and Minor wil be taken into consideration.</p>
 
 <b>Parameters</b>
 

--- a/docs/CodeDoc/Atc/System.md
+++ b/docs/CodeDoc/Atc/System.md
@@ -471,6 +471,16 @@ bool AreClose(this double value1, double value2)
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value1`&nbsp;&nbsp;-&nbsp;&nbsp;The value1.<br />
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value2`&nbsp;&nbsp;-&nbsp;&nbsp;The value2.<br />
+#### CountDecimalPoints
+
+```csharp
+int CountDecimalPoints(this double value)
+```
+<p><b>Summary:</b> Returns the numbers of decimal points in the value.</p>
+
+<b>Parameters</b>
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value.<br />
 #### CurrencyRounding
 
 ```csharp

--- a/src/Atc.CodeDocumentation/XmlDocumentCommentParser.cs
+++ b/src/Atc.CodeDocumentation/XmlDocumentCommentParser.cs
@@ -39,7 +39,7 @@ namespace Atc.CodeDocumentation
                     summaryXml = Regex.Replace(summaryXml, @"<para\s*/>", Environment.NewLine);
                     summaryXml = Regex.Replace(summaryXml, @"<see cref=""\w:([^\""]*)""\s*\/>", m => ResolveSeeElement(m, namespaceMatch));
 
-                    var summary = Regex.Replace(summaryXml, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[1].Value}`");
+                    var summary = Regex.Replace(summaryXml, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[2].Value}`");
                     if (summary.Length > 0)
                     {
                         summary = string.Join("  ", summary.Split(new[] { "\r", "\n", "\t" }, StringSplitOptions.RemoveEmptyEntries).Select(y => y.Trim()));

--- a/src/Atc.CodeDocumentation/XmlDocumentCommentParser.cs
+++ b/src/Atc.CodeDocumentation/XmlDocumentCommentParser.cs
@@ -45,6 +45,8 @@ namespace Atc.CodeDocumentation
                         summary = string.Join("  ", summary.Split(new[] { "\r", "\n", "\t" }, StringSplitOptions.RemoveEmptyEntries).Select(y => y.Trim()));
                     }
 
+                    summary = summary.TrimExtended();
+
                     var returns = ((string)x.Element("returns")) ?? string.Empty;
                     var remarks = ((string)x.Element("remarks")) ?? string.Empty;
                     var code = (string)x.Element("code") ?? string.Empty;

--- a/src/Atc/Extensions/BaseTypes/DoubleExtensions.cs
+++ b/src/Atc/Extensions/BaseTypes/DoubleExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 
 // ReSharper disable once CheckNamespace
 namespace System
@@ -178,6 +178,22 @@ namespace System
         public static double RoundOffPercent(this double percent)
         {
             return RoundOff(percent, 2);
+        }
+
+        /// <summary>
+        /// Returns the numbers of decimal points in the value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public static int CountDecimalPoints(this double value)
+        {
+            var precision = 0;
+
+            while (value * Math.Pow(10, precision) != Math.Round(value * Math.Pow(10, precision)))
+            {
+                precision++;
+            }
+
+            return precision;
         }
     }
 }

--- a/src/Atc/Math/MathEx.cs
+++ b/src/Atc/Math/MathEx.cs
@@ -52,31 +52,23 @@ namespace Atc.Math
         /// <param name="v2">The v2.</param>
         public static double GreatestCommonDivisor(double v1, double v2)
         {
-            // Take absolute values
-            if (v1 < 0)
+            var maxDecimalPoints = System.Math.Max(
+                v1.CountDecimalPoints(),
+                v2.CountDecimalPoints());
+
+            var v1Int = (int)v1;
+            var v2Int = (int)v2;
+
+            if (maxDecimalPoints > 0)
             {
-                v1 = -v1;
+                v1Int = (int)(v1 * maxDecimalPoints * 10);
+                v2Int = (int)(v2 * maxDecimalPoints * 10);
             }
 
-            if (v2 < 0)
-            {
-                v2 = -v2;
-            }
-
-            do
-            {
-                if (v1 < v2)
-                {
-                    v2 = Interlocked.Exchange(ref v1, v2); // swap the two operands
-                }
-
-                v1 %= v2;
-            }
-
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            while (v1 != 0);
-
-            return v2;
+            var greatestCommonIntDivisor = (double)GreatestCommonDivisor(v1Int, v2Int);
+            return maxDecimalPoints > 0
+                ? greatestCommonIntDivisor / (maxDecimalPoints * 10)
+                : greatestCommonIntDivisor;
         }
 
         /// <summary>

--- a/src/Atc/Math/MathEx.cs
+++ b/src/Atc/Math/MathEx.cs
@@ -72,21 +72,42 @@ namespace Atc.Math
         }
 
         /// <summary>
-        /// Gets the divisors less than or equal.
+        /// Gets divisors for <paramref name="value"/> that is less than or equal to the specified <paramref name="max"/> value.
         /// </summary>
-        /// <param name="value">The value.</param>
-        /// <param name="max">The maximum.</param>
+        /// <param name="value">The value to get divisors of.</param>
+        /// <param name="max">The maximum divisor threshold.</param>
         public static IEnumerable<int> GetDivisorsLessThanOrEqual(int value, int max)
         {
-            max = System.Math.Min(max, System.Math.Abs(value / 2));
-            yield return 1;
-            for (int i = 2; i <= max; ++i)
+            if (value < 1)
             {
-                if (value % i == 0)
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} cannot be less than 1.");
+            }
+
+            if (max < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(max), max, $"{nameof(max)} cannot be less than 1.");
+            }
+
+            IEnumerable<int> Iterator()
+            {
+                int halfMax = System.Math.Min(max, System.Math.Abs(value / 2));
+                yield return 1;
+
+                for (int i = 2; i <= halfMax; ++i)
                 {
-                    yield return i;
+                    if (value % i == 0)
+                    {
+                        yield return i;
+                    }
+                }
+
+                if (max != 1 && max >= value)
+                {
+                    yield return value;
                 }
             }
+
+            return Iterator();
         }
 
         /// <summary>

--- a/test/Atc.Rest.Tests/CodeComplianceTests.cs
+++ b/test/Atc.Rest.Tests/CodeComplianceTests.cs
@@ -41,7 +41,7 @@ namespace Atc.Rest.Tests
             typeof(ResultFactory),
             typeof(AuthorizationOptions),
 
-            // UnitTests is made, but CodeCompliance test cannot detect this
+            // UnitTests are made, but CodeCompliance test cannot detect this
             typeof(FormFileExtensions),
         };
 

--- a/test/Atc.Tests/CodeComplianceTests.cs
+++ b/test/Atc.Tests/CodeComplianceTests.cs
@@ -18,8 +18,10 @@ namespace Atc.Tests
         private readonly List<Type> excludeTypes = new List<Type>
         {
             // TODO: Add UnitTest and remove from this list!!
-            typeof(TaskExtensions),
             typeof(MathEx),
+
+            // UnitTests are made, but CodeCompliance test cannot detect this
+            typeof(TaskExtensions),
         };
 
         public CodeComplianceTests(ITestOutputHelper testOutputHelper)

--- a/test/Atc.Tests/Extensions/BaseTypes/DoubleExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/BaseTypes/DoubleExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 
 namespace Atc.Tests.Extensions.BaseTypes
@@ -271,6 +271,23 @@ namespace Atc.Tests.Extensions.BaseTypes
         {
             // Act
             var actual = input.RoundOffPercent();
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0, 9)]
+        [InlineData(1, 9.9)]
+        [InlineData(2, 9.99)]
+        [InlineData(3, 9.999)]
+        [InlineData(4, 9.9999000000)]
+        [InlineData(15, 9.1234567891012345)]
+        [InlineData(30, 5.821e-27)]
+        public void CountDecimalPoints(int expected, double input)
+        {
+            // Act
+            var actual = input.CountDecimalPoints();
 
             // Assert
             Assert.Equal(expected, actual);

--- a/test/Atc.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -236,7 +236,7 @@ namespace Atc.Tests.Extensions
             var actual = input.ToXml();
 
             // Assert
-            Assert.Equal(expected.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal), actual.ToString().Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal));
+            Assert.Equal(expected.EnsureEnvironmentNewLines(), actual.ToString().EnsureEnvironmentNewLines());
         }
     }
 }

--- a/test/Atc.Tests/Math/MathExTests.cs
+++ b/test/Atc.Tests/Math/MathExTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Atc.Math;
 using Xunit;
 
@@ -34,5 +36,29 @@ namespace Atc.Tests.Math
             // Assert
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData(new[] { 1, 2, 4, 8 }, 16, 8)]
+        [InlineData(new[] { 1 }, 1, 1)]
+        [InlineData(new[] { 1, 3 }, 9, 5)]
+        [InlineData(new[] { 1, 3, 9 }, 9, 9)]
+        [InlineData(new[] { 1, 3, 9 }, 9, 29)]
+        [InlineData(new[] { 1, 5, 13, 65, 1381, 6905, 17953 }, 89765, 44882)]
+        public void GetDivisorsLessThanOrEqual(IEnumerable<int> expected, int value, int max)
+        {
+            // Act
+            var actual = MathEx.GetDivisorsLessThanOrEqual(value, max);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(-1, 10)]
+        [InlineData(0, 10)]
+        [InlineData(10, -1)]
+        [InlineData(10, 0)]
+        public void GetDivisorsLessThanOrEqual_Expected_ArgumentOutOfRangeException(int value, int max)
+            => Assert.Throws<ArgumentOutOfRangeException>(() => MathEx.GetDivisorsLessThanOrEqual(value, max));
     }
 }

--- a/test/Atc.Tests/Math/MathExTests.cs
+++ b/test/Atc.Tests/Math/MathExTests.cs
@@ -60,5 +60,19 @@ namespace Atc.Tests.Math
         [InlineData(10, 0)]
         public void GetDivisorsLessThanOrEqual_Expected_ArgumentOutOfRangeException(int value, int max)
             => Assert.Throws<ArgumentOutOfRangeException>(() => MathEx.GetDivisorsLessThanOrEqual(value, max));
+
+        [Theory]
+        [InlineData(0, int.MinValue)]
+        [InlineData(0, -1)]
+        [InlineData(1, 0)]
+        [InlineData(1, 1)]
+        [InlineData(1, int.MaxValue)]
+        public void Step(int expected, int x)
+        {
+            // Act
+            var actual = MathEx.Step(x);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/test/Atc.Tests/Math/MathExTests.cs
+++ b/test/Atc.Tests/Math/MathExTests.cs
@@ -72,6 +72,7 @@ namespace Atc.Tests.Math
             // Act
             var actual = MathEx.Step(x);
 
+            // Assert
             Assert.Equal(expected, actual);
         }
     }

--- a/test/Atc.Tests/Math/MathExTests.cs
+++ b/test/Atc.Tests/Math/MathExTests.cs
@@ -1,0 +1,38 @@
+using Atc.Math;
+using Xunit;
+
+namespace Atc.Tests.Math
+{
+    public class MathExTests
+    {
+        [Theory]
+        [InlineData(3, 9, 3)]
+        [InlineData(4, 8, 12)]
+        [InlineData(6, 54, 24)]
+        [InlineData(14, 42, 56)]
+        [InlineData(6, 48, 18)]
+        [InlineData(21, 1071, 462)]
+        [InlineData(65, 89765, 12350)]
+        public void GreatestCommonDivisor(int expected, int v1, int v2)
+        {
+            // Act
+            var actual = MathEx.GreatestCommonDivisor(v1, v2);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0.5, 1.5, 2.5)]
+        [InlineData(3.3, 9.9, 3.3)]
+        [InlineData(9.5, 89765.5, 12350)]
+        public void GreatestCommonDivisor_As_Double(double expected, double v1, double v2)
+        {
+            // Act
+            var actual = MathEx.GreatestCommonDivisor(v1, v2);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
### Added CountDecimalPoints to DoubleExtensions
counts the decimal precision in a given double.

### Fixed GreatestCommonDivisors for double and added tests
Now works properly with decimal numbers.

###  Improved GetDivisorsLessThanOrEqual and added tests
Throws ArgumentOutOfRange exceptions if value or max is less than 1.
Now also returns the input value itself as a divisor, if max is equal to or greater than value

### Added Step Test

### Fixed <paramref="x"> XML tag not being substituted correctly by CodeDocumentation generator

### Fixed double spacing in generated documentation when XML summary has linebreaks.