### PR TITLE
Fixed InvokeExecute hanging infinitely

### DIFF
--- a/src/Atc/Helpers/ProcessHelper.cs
+++ b/src/Atc/Helpers/ProcessHelper.cs
@@ -375,10 +375,10 @@ namespace Atc.Helpers
             {
                 process.Start();
 
-                process.WaitForExit();
-
                 var standardOutput = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
                 var standardError = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+
+                process.WaitForExit();
 
                 var message = string.IsNullOrEmpty(standardError)
                     ? standardOutput


### PR DESCRIPTION
If stdout or stderr has not been registered before WaitForExit(), it will never return while on Windows platform.