### PR TITLE
Refactor Base64 conversion extensions

### DIFF
--- a/docs/CodeDoc/Atc/IndexExtended.md
+++ b/docs/CodeDoc/Atc/IndexExtended.md
@@ -622,10 +622,10 @@
 - [StringExtensions](System.md#stringextensions)
   -  Static Methods
      - Alphabetize(this string value)
-     - Base64Decode(this string base64EData)
-     - Base64DecodeAsAscii(this string base64EData)
+     - Base64Decode(this string base64EncodedData)
+     - Base64Decode(this string base64EncodedData, Encoding encoding)
      - Base64Encode(this string value)
-     - Base64EncodeAsAscii(this string value)
+     - Base64Encode(this string value, Encoding encoding)
      - CamelCase(this string value)
      - Contains(this string value, string containsValue, bool ignoreCaseSensitive = True)
      - Cut(this string value, int maxLength, string appendValue = ...)

--- a/docs/CodeDoc/Atc/System.md
+++ b/docs/CodeDoc/Atc/System.md
@@ -1012,36 +1012,36 @@ Extensions for the string class.
 ><b>Returns:</b> The string sorted alphabetically.
 #### Base64Decode
 >```csharp
->string Base64Decode(this string base64EData)
+>string Base64Decode(this string base64EncodedData)
 >```
-><b>Summary:</b> Base64s the decode.
+><b>Summary:</b> Decodes the `base64EncodedData`<see langword="string" /> using UTF8.
 >
 ><b>Parameters:</b><br>
->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`base64EData`&nbsp;&nbsp;-&nbsp;&nbsp;The base64 e data.<br />
-#### Base64DecodeAsAscii
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`base64EncodedData`&nbsp;&nbsp;-&nbsp;&nbsp;The Base64 encoded data.<br />
+#### Base64Decode
 >```csharp
->string Base64DecodeAsAscii(this string base64EData)
+>string Base64Decode(this string base64EncodedData, Encoding encoding)
 >```
-><b>Summary:</b> Base64s the decode as ASCII.
+><b>Summary:</b> Decodes the `base64EncodedData`<see langword="string" /> using UTF8.
 >
 ><b>Parameters:</b><br>
->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`base64EData`&nbsp;&nbsp;-&nbsp;&nbsp;The base64 e data.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`base64EncodedData`&nbsp;&nbsp;-&nbsp;&nbsp;The Base64 encoded data.<br />
 #### Base64Encode
 >```csharp
 >string Base64Encode(this string value)
 >```
-><b>Summary:</b> Base64s the encode.
+><b>Summary:</b> Encodes the `value` to Base64 in UTF8.
 >
 ><b>Parameters:</b><br>
->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value.<br />
-#### Base64EncodeAsAscii
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The string value to encode<br />
+#### Base64Encode
 >```csharp
->string Base64EncodeAsAscii(this string value)
+>string Base64Encode(this string value, Encoding encoding)
 >```
-><b>Summary:</b> Base64s the encode as ASCII.
+><b>Summary:</b> Encodes the `value` to Base64 in UTF8.
 >
 ><b>Parameters:</b><br>
->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The string value to encode<br />
 #### CamelCase
 >```csharp
 >string CamelCase(this string value)

--- a/src/Atc/Extensions/StringExtensions.cs
+++ b/src/Atc/Extensions/StringExtensions.cs
@@ -320,47 +320,51 @@ namespace System
         }
 
         /// <summary>
-        /// Base64s the encode.
+        /// Encodes the <paramref name="value"/> to Base64 in UTF8.
         /// </summary>
-        /// <param name="value">The value.</param>
-        public static string? Base64Encode(this string value)
+        /// <param name="value">The string value to encode</param>
+        public static string Base64Encode(this string value)
         {
-            return string.IsNullOrEmpty(value)
-                ? null
-                : Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+            return value.Base64Encode(Encoding.UTF8);
         }
 
         /// <summary>
-        /// Base64s the encode as ASCII.
+        /// Encodes the <paramref name="value"/> to Base64 using the specified <paramref name="encoding"/>.
         /// </summary>
-        /// <param name="value">The value.</param>
-        public static string? Base64EncodeAsAscii(this string value)
+        /// <param name="value">The string value to encode.</param>
+        /// <param name="encoding">The encoding.</param>
+        public static string Base64Encode(this string value, Encoding encoding)
         {
-            return string.IsNullOrEmpty(value)
-                ? null
-                : Convert.ToBase64String(Encoding.ASCII.GetBytes(value));
+            if (encoding is null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            return Convert.ToBase64String(encoding.GetBytes(value));
         }
 
         /// <summary>
-        /// Base64s the decode.
+        /// Decodes the <paramref name="base64EncodedData"/> <see langword="string"/> using UTF8.
         /// </summary>
-        /// <param name="base64EData">The base64 e data.</param>
-        public static string? Base64Decode(this string base64EData)
+        /// <param name="base64EncodedData">The Base64 encoded data.</param>
+        public static string Base64Decode(this string base64EncodedData)
         {
-            return string.IsNullOrEmpty(base64EData)
-                ? null
-                : Encoding.UTF8.GetString(Convert.FromBase64String(base64EData));
+            return base64EncodedData.Base64Decode(Encoding.UTF8);
         }
 
         /// <summary>
-        /// Base64s the decode as ASCII.
+        /// Decodes the <paramref name="base64EncodedData"/> using the specified <paramref name="encoding"/>
         /// </summary>
-        /// <param name="base64EData">The base64 e data.</param>
-        public static string? Base64DecodeAsAscii(this string base64EData)
+        /// <param name="base64EncodedData">The Base64 encoded data.</param>
+        /// <param name="encoding">The encoding.</param>
+        public static string Base64Decode(this string base64EncodedData, Encoding encoding)
         {
-            return string.IsNullOrEmpty(base64EData)
-                ? null
-                : Encoding.ASCII.GetString(Convert.FromBase64String(base64EData));
+            if (encoding is null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            return encoding.GetString(Convert.FromBase64String(base64EncodedData));
         }
 
         /// <summary>

--- a/test/Atc.Tests/Extensions/StringExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/StringExtensionsTests.cs
@@ -122,55 +122,71 @@ namespace Atc.Tests.Extensions
             => Assert.Equal(expected, input.TryParseDate(out var _, GlobalizationConstants.DanishCultureInfo, dateTimeStyles));
 
         [Theory]
-        [InlineData("Hallo world")]
-        public void Base64Encode(string input)
+        [InlineData("", "")]
+        [InlineData("Zg==", "f")]
+        [InlineData("Zm8=", "fo")]
+        [InlineData("Zm9v", "foo")]
+        [InlineData("Zm9vYg==", "foob")]
+        [InlineData("Zm9vYmE=", "fooba")]
+        [InlineData("Zm9vYmFy", "foobar")]
+        public void Base64Encode(string expected, string input)
         {
             // Act
-            var encodeData = input.Base64Encode();
+            var actual = input.Base64Encode();
 
             // Assert
-            Assert.NotNull(encodeData);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [InlineData("Hallo world")]
-        public void Base64EncodeAsAscii(string input)
+        [InlineData("", "")]
+        [InlineData("Zg==", "f")]
+        [InlineData("Zm8=", "fo")]
+        [InlineData("Zm9v", "foo")]
+        [InlineData("Zm9vYg==", "foob")]
+        [InlineData("Zm9vYmE=", "fooba")]
+        [InlineData("Zm9vYmFy", "foobar")]
+        public void Base64Encode_EncodingOverload(string expected, string input)
         {
             // Act
-            var encodeData = input.Base64EncodeAsAscii();
+            var actual = input.Base64Encode(System.Text.Encoding.ASCII);
 
             // Assert
-            Assert.NotNull(encodeData);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [InlineData("Hallo world")]
-        public void Base64Decode(string input)
+        [InlineData("", "")]
+        [InlineData("f", "Zg==")]
+        [InlineData("fo", "Zm8=")]
+        [InlineData("foo", "Zm9v")]
+        [InlineData("foob", "Zm9vYg==")]
+        [InlineData("fooba", "Zm9vYmE=")]
+        [InlineData("foobar", "Zm9vYmFy")]
+        public void Base64Decode(string expected, string input)
         {
-            // Arrange
-            var encodeData = input.Base64Encode();
-
             // Act
-            var decodeData = encodeData!.Base64Decode();
+            var actual = input.Base64Decode();
 
             // Assert
-            Assert.NotNull(decodeData);
-            Assert.Equal(input.Length, decodeData.Length);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [InlineData("Hallo world")]
-        public void Base64DecodeAsAscii(string input)
+        [InlineData("", "")]
+        [InlineData("f", "Zg==")]
+        [InlineData("fo", "Zm8=")]
+        [InlineData("foo", "Zm9v")]
+        [InlineData("foob", "Zm9vYg==")]
+        [InlineData("fooba", "Zm9vYmE=")]
+        [InlineData("foobar", "Zm9vYmFy")]
+        public void Base64Decode_EncodingOverload(string expected, string input)
         {
-            // Arrange
-            var encodeData = input.Base64EncodeAsAscii();
-
             // Act
-            var decodeData = encodeData!.Base64DecodeAsAscii();
+            var actual = input.Base64Decode(System.Text.Encoding.ASCII);
 
             // Assert
-            Assert.NotNull(decodeData);
-            Assert.Equal(input.Length, decodeData.Length);
+            Assert.Equal(expected, actual);
         }
 
         [Theory]


### PR DESCRIPTION
Instead of having a method for each encoding type, we have UTF8 as the default impl and an extra overload with an encoding parameter.
Don't return null when given string value is empty.