### PR TITLE
Only resolve enum values for swagger spec if enum type name is unique…

### DIFF
--- a/src/Atc.Rest.Extended/Filters/SwaggerEnumDescriptionsDocumentFilter.cs
+++ b/src/Atc.Rest.Extended/Filters/SwaggerEnumDescriptionsDocumentFilter.cs
@@ -118,11 +118,15 @@ namespace Atc.Rest.Extended.Filters
         }
 
         private static Type? GetEnumTypeByName(string enumTypeName)
-        {
-            return AppDomain.CurrentDomain
+            => AppDomain.CurrentDomain
                 .GetAssemblies()
-                .SelectMany(x => x.GetTypes())
-                .FirstOrDefault(x => string.Equals(x.Name, enumTypeName, StringComparison.Ordinal));
-        }
+                .SelectMany(x => x.GetTypes().Where(t => t.IsEnum))
+                .Where(x => string.Equals(x.Name, enumTypeName, StringComparison.Ordinal))
+                .ToArray()
+            switch
+            {
+                { Length: 1 } a => a[0],
+                _ => null,
+            };
     }
 }


### PR DESCRIPTION
… within the AppDomain

This resolves an issue where Swashbuckle fails to generate the spec if an enum in the contract shares the name with any other type in the AppDomain that has a different set of members.

This issue is currently preventing our swagger UI from loading.