### PR TITLE
if --buildFile is not specified for BuildAndCollectErrors and there a…

### DIFF
--- a/src/Atc.DotNet/DotnetBuildHelper.cs
+++ b/src/Atc.DotNet/DotnetBuildHelper.cs
@@ -105,6 +105,13 @@ namespace Atc.DotNet
                     cancellationToken)
                 .ConfigureAwait(false);
 
+            if (output.StartsWith("Please specify which", StringComparison.Ordinal) &&
+                output.Contains("option: --buildFile", StringComparison.Ordinal))
+            {
+                stopwatch.Stop();
+                throw new IOException(output);
+            }
+
             var parsedErrors = ParseBuildOutput(output);
             int totalErrors = parsedErrors.Sum(parsedError => parsedError.Value);
 


### PR DESCRIPTION
…re too many sln/csproj files in the path, then throw a IOException