### PR TITLE
Add IsNewerMinorReleaseThen

### DIFF
--- a/docs/CodeDoc/Atc/IndexExtended.md
+++ b/docs/CodeDoc/Atc/IndexExtended.md
@@ -818,6 +818,7 @@
      - CompareTo(this Version version, Version otherVersion, int significantParts = 4, int startingPart = 1)
      - GreaterThan(this Version version, Version otherVersion, int significantParts = 4, int startingPart = 1)
      - GreaterThanOrEqualTo(this Version version, Version otherVersion, int significantParts = 4, int startingPart = 1)
+     - IsNewerMinorReleaseThen(this Version version, Version otherVersion)
 - [ViewModelException](System.md#viewmodelexception)
 
 ## [System.Collections.Generic](System.Collections.Generic.md)

--- a/docs/CodeDoc/Atc/System.md
+++ b/docs/CodeDoc/Atc/System.md
@@ -2272,6 +2272,27 @@ The exception that is thrown when an user is not found.
 >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`startingPart`&nbsp;&nbsp;-&nbsp;&nbsp;The starting parts.<br />
 >
 ><b>Returns:</b> `true` if 'otherVersion' is greater then or equal to the current 'version'; otherwise, `false`.
+#### IsNewerMinorReleaseThen
+>```csharp
+>bool IsNewerMinorReleaseThen(this Version version, Version otherVersion)
+>```
+><b>Summary:</b> Determines whether 'version' is newer then the 'otherVersion'.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`version`&nbsp;&nbsp;-&nbsp;&nbsp;The version.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`otherVersion`&nbsp;&nbsp;-&nbsp;&nbsp;The other version.<br />
+>
+><b>Returns:</b> `true` if 'otherVersion' is newer then the 'version'; otherwise, `false`.
+>
+><b>Code example:</b>
+>```csharp
+>    4.8.8.0 is newer then 4.5.3.3
+>    4.5.8.0 is newer then 4.5.3.3
+>    4.8.3.0 is newer then 4.5.3.3
+>    4.5.4.0 is newer then 4.5.3.3
+>    4.5.3.0 is NOT newer then 4.5.3.3
+>    5.8.8.0 is NOT newer then 4.5.3.3
+>```
 
 <br />
 

--- a/src/Atc/Extensions/VersionExtensions.cs
+++ b/src/Atc/Extensions/VersionExtensions.cs
@@ -122,4 +122,34 @@ public static class VersionExtensions
 
         return version.CompareTo(otherVersion, significantParts, startingPart) >= 0;
     }
+
+    /// <summary>Determines whether 'version' is newer then the 'otherVersion'.</summary>
+    /// <param name="version">The version.</param>
+    /// <param name="otherVersion">The other version.</param>
+    /// <example>
+    ///     4.8.8.0 is newer then 4.5.3.3
+    ///     4.5.8.0 is newer then 4.5.3.3
+    ///     4.8.3.0 is newer then 4.5.3.3
+    ///     4.5.4.0 is newer then 4.5.3.3
+    ///     4.5.3.0 is NOT newer then 4.5.3.3
+    ///     5.8.8.0 is NOT newer then 4.5.3.3
+    /// </example>
+    /// <returns>
+    ///   <c>true</c> if 'otherVersion' is newer then the 'version'; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsNewerMinorReleaseThen(this Version version, Version? otherVersion)
+    {
+        if (version is null)
+        {
+            throw new ArgumentNullException(nameof(version));
+        }
+
+        if (otherVersion is null)
+        {
+            return true;
+        }
+
+        return version.Major <= otherVersion.Major &&
+               version.GreaterThan(otherVersion, significantParts: 4, startingPart: 2);
+    }
 }

--- a/test/Atc.Tests/Extensions/VersionExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/VersionExtensionsTests.cs
@@ -158,4 +158,21 @@ public class VersionExtensionsTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Theory]
+    [InlineData(true, new[] { 4, 8, 8, 0 }, new[] { 4, 5, 3, 3 })]
+    [InlineData(true, new[] { 4, 5, 8, 0 }, new[] { 4, 5, 3, 3 })]
+    [InlineData(true, new[] { 4, 8, 3, 0 }, new[] { 4, 5, 3, 3 })]
+    [InlineData(true, new[] { 4, 5, 4, 0 }, new[] { 4, 5, 3, 3 })]
+    [InlineData(false, new[] { 4, 5, 3, 0 }, new[] { 4, 5, 3, 3 })]
+    [InlineData(false, new[] { 5, 8, 8, 0 }, new[] { 4, 5, 3, 3 })]
+    public void IsNewerMinorReleaseThen(bool expected, int[] inputA, int[] inputB)
+    {
+        var versionA = new Version(inputA[0], inputA[1], inputA[2], inputA[3]);
+        var versionB = new Version(inputB[0], inputB[1], inputB[2], inputB[3]);
+
+        var actual = versionA.IsNewerMinorReleaseThen(versionB);
+
+        Assert.Equal(expected, actual);
+    }
 }


### PR DESCRIPTION
Add IsNewerMinorReleaseThen method to be more clear in meaning then comparing nuget-versions (just a wrapper for GreaterThan) and ensure Major-release is not retruns true