### PR TITLE
Improve AssemblyHelper

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,10 +43,10 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.70" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.92" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.csproj
+++ b/src/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Atc.OpenApi/Atc.OpenApi.csproj
+++ b/src/Atc.OpenApi/Atc.OpenApi.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.6" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.csproj
+++ b/src/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.XUnit/Atc.XUnit.csproj
+++ b/src/Atc.XUnit/Atc.XUnit.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EPPlus" Version="6.2.7" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7345" />
+    <PackageReference Include="EPPlus" Version="6.2.10" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="8.1.1.7464" />
     <PackageReference Include="Mono.Reflection" Version="2.0.0">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc/Helpers/AssemblyHelper.cs
+++ b/src/Atc/Helpers/AssemblyHelper.cs
@@ -27,9 +27,10 @@ public static class AssemblyHelper
             throw new IOException("File not found");
         }
 
-        if (!assemblyFile.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase))
+        if (!assemblyFile.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase) &&
+            !assemblyFile.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
         {
-            throw new IOException("File is not a dll");
+            throw new IOException("File is not a dll or a executable file");
         }
 
         var bytes = ReadAsBytes(assemblyFile);
@@ -43,7 +44,14 @@ public static class AssemblyHelper
             throw new IOException("File has a 0 byte length");
         }
 
-        return Assembly.Load(bytes);
+        try
+        {
+            return Assembly.Load(bytes);
+        }
+        catch (BadImageFormatException)
+        {
+            throw new IOException("File is not a valid Assembly");
+        }
     }
 
     /// <summary>
@@ -64,9 +72,10 @@ public static class AssemblyHelper
             throw new IOException("File not found");
         }
 
-        if (!assemblyFile.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase))
+        if (!assemblyFile.Extension.Equals(".dll", StringComparison.OrdinalIgnoreCase) &&
+            !assemblyFile.Extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
         {
-            throw new IOException("File is not a dll");
+            throw new IOException("File is not a dll or a executable file");
         }
 
         try

--- a/src/Atc/Helpers/Enums/CardinalDirectionTypeHelper.cs
+++ b/src/Atc/Helpers/Enums/CardinalDirectionTypeHelper.cs
@@ -37,6 +37,7 @@ public static class CardinalDirectionTypeHelper
     /// <param name="cardinalDirectionTypeToInclude">The cardinal direction type to include.</param>
     /// <param name="cardinalDirectionType">Type of the cardinal direction.</param>
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "OK.")]
+    [SuppressMessage("Bug", "S2589:Conditionally executed code should be reachable", Justification = "OK.")]
     public static CardinalDirectionType GetWhenRotateRight(CardinalDirectionType cardinalDirectionTypeToInclude, CardinalDirectionType cardinalDirectionType)
     {
         var returnValue = CardinalDirectionType.None;
@@ -265,6 +266,7 @@ public static class CardinalDirectionTypeHelper
     /// <param name="angle">The angle.</param>
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "OK.")]
     [SuppressMessage("Critical Code Smell", "S3776:Cognitive Complexity of methods should not be too high", Justification = "OK.")]
+    [SuppressMessage("Bug", "S2589:Conditionally executed code should be reachable", Justification = "OK.")]
     public static CardinalDirectionType GetTheClosestByAngle(CardinalDirectionType combinedCardinalDirectionType, double angle)
     {
         if (angle < 0 || angle > 360)

--- a/src/Atc/Helpers/NetworkInformationHelper.cs
+++ b/src/Atc/Helpers/NetworkInformationHelper.cs
@@ -82,6 +82,7 @@ public static class NetworkInformationHelper
         }
     }
 
+    [SuppressMessage("Bug", "S2583:Conditionally executed code should be reachable", Justification = "OK.")]
     public static IPAddress? GetPublicIpAddress()
     {
         string? response = null;

--- a/src/Atc/Helpers/TaskHelper.cs
+++ b/src/Atc/Helpers/TaskHelper.cs
@@ -53,6 +53,7 @@ public static class TaskHelper
     /// </remarks>
     [SuppressMessage("Microsoft.Design", "CA1031:Do not catch general exception types", Justification = "OK.")]
     [SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "OK.")]
+    [SuppressMessage("Code Smell", "S112:General exceptions should never be thrown", Justification = "OK.")]
     public static async Task WhenAll(IEnumerable<Task> tasks)
     {
         var allTasks = Task.WhenAll(tasks);
@@ -82,6 +83,7 @@ public static class TaskHelper
     /// </remarks>
     [SuppressMessage("Microsoft.Design", "CA1031:Do not catch general exception types", Justification = "OK.")]
     [SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "OK.")]
+    [SuppressMessage("Code Smell", "S112:General exceptions should never be thrown", Justification = "OK.")]
     public static async Task<IEnumerable<T>> WhenAll<T>(IEnumerable<Task<T>> tasks)
     {
         var allTasks = Task.WhenAll(tasks);
@@ -110,6 +112,7 @@ public static class TaskHelper
     /// </remarks>
     [SuppressMessage("Microsoft.Design", "CA1031:Do not catch general exception types", Justification = "OK.")]
     [SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "OK.")]
+    [SuppressMessage("Code Smell", "S112:General exceptions should never be thrown", Justification = "OK.")]
     public static async Task<IEnumerable<T>> WhenAll<T>(params Task<T>[] tasks)
     {
         var allTasks = Task.WhenAll(tasks);

--- a/test/Atc.CodeAnalysis.CSharp.Tests/Atc.CodeAnalysis.CSharp.Tests.csproj
+++ b/test/Atc.CodeAnalysis.CSharp.Tests/Atc.CodeAnalysis.CSharp.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.CodeDocumentation.Tests/Atc.CodeDocumentation.Tests.csproj
+++ b/test/Atc.CodeDocumentation.Tests/Atc.CodeDocumentation.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Console.Spectre.Tests/Atc.Console.Spectre.Tests.csproj
+++ b/test/Atc.Console.Spectre.Tests/Atc.Console.Spectre.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.DotNet.Tests/Atc.DotNet.Tests.csproj
+++ b/test/Atc.DotNet.Tests/Atc.DotNet.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.OpenApi.Tests/Atc.OpenApi.Tests.csproj
+++ b/test/Atc.OpenApi.Tests/Atc.OpenApi.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Rest.Extended.Tests/Atc.Rest.Extended.Tests.csproj
+++ b/test/Atc.Rest.Extended.Tests/Atc.Rest.Extended.Tests.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Rest.FluentAssertions.Tests/Atc.Rest.FluentAssertions.Tests.csproj
+++ b/test/Atc.Rest.FluentAssertions.Tests/Atc.Rest.FluentAssertions.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Rest.HealthChecks.Tests/Atc.Rest.HealthChecks.Tests.csproj
+++ b/test/Atc.Rest.HealthChecks.Tests/Atc.Rest.HealthChecks.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Rest.Tests/Atc.Rest.Tests.csproj
+++ b/test/Atc.Rest.Tests/Atc.Rest.Tests.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Tests/Atc.Tests.csproj
+++ b/test/Atc.Tests/Atc.Tests.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.XUnit.Tests/Atc.XUnit.Tests.csproj
+++ b/test/Atc.XUnit.Tests/Atc.XUnit.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.77" />
+    <PackageReference Include="Atc.Test" Version="1.0.79" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
* Entend AssemblyHelper on Load and ReadAsBytes methods to allow the extension ".exe"
* Improve the use of Assembly.Load, by trt/catch BadImageFormatException into a IOException with a better explanation.
* Nuget updates