### PR TITLE
feat: use Meziantou.Polyfill to allow for nullable static analysis in HttpClientRequestResult

### DIFF
--- a/src/Atc/Atc.csproj
+++ b/src/Atc/Atc.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.38">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />
@@ -70,4 +74,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <PropertyGroup>
+    <MeziantouPolyfill_IncludedPolyfills>T:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute</MeziantouPolyfill_IncludedPolyfills>
+  </PropertyGroup>
+  
 </Project>

--- a/src/Atc/Data/Models/HttpClientRequestResult.cs
+++ b/src/Atc/Data/Models/HttpClientRequestResult.cs
@@ -64,12 +64,15 @@ public sealed class HttpClientRequestResult<TData>
 
     public Exception? Exception { get; set; }
 
+    [MemberNotNullWhen(true, nameof(Data))]
     public bool HasData
         => Data is not null;
 
+    [MemberNotNullWhen(true, nameof(Message))]
     public bool HasMessage
         => !string.IsNullOrEmpty(Message);
 
+    [MemberNotNullWhen(true, nameof(Exception))]
     public bool HasException
         => Exception is not null;
 


### PR DESCRIPTION
The library does not contain attributes to be used by the compiler for static nullable analysis.
This results in warnings even though `HttpClientRequestResult<TData>.HasData` was already evaluated to be true:

![image](https://github.com/atc-net/atc/assets/59445808/f3fbcec7-21af-4cee-96a1-0d608eb1a6e1)

There are probably more classes where this is useful, but this is where i encountered it.