### PR TITLE
Add StartProcess methods to ProcessHelper

### DIFF
--- a/docs/CodeDoc/Atc/Atc.Helpers.md
+++ b/docs/CodeDoc/Atc/Atc.Helpers.md
@@ -2731,6 +2731,34 @@ Provides utility methods for executing external processes, managing process life
 >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`timeoutInSec`&nbsp;&nbsp;-&nbsp;&nbsp;The maximum time in seconds to wait for the process to terminate. Default is 30 seconds.<br />
 >
 ><b>Returns:</b> A tuple containing success status and a descriptive message.
+#### StartProcess
+>```csharp
+>Process StartProcess(FileInfo fileInfo, string arguments = , bool runAsAdministrator = False)
+>```
+><b>Summary:</b> Starts a process without waiting for it to complete. Supports UAC elevation via the "runas" verb when `runAsAdministrator` is <see langword="true" />.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`fileInfo`&nbsp;&nbsp;-&nbsp;&nbsp;The executable file to run.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`arguments`&nbsp;&nbsp;-&nbsp;&nbsp;The command-line arguments to pass to the executable.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`runAsAdministrator`&nbsp;&nbsp;-&nbsp;&nbsp;If , launches the process with elevated privileges (triggers a UAC prompt on Windows).<br />
+>
+><b>Returns:</b> The started `System.Diagnostics.Process`, or <see langword="null" /> if the process could not be started.
+>
+><b>Remarks:</b> Unlike `Atc.Helpers.ProcessHelper.Execute(System.IO.FileInfo,System.String,System.Boolean,System.UInt16,System.Threading.CancellationToken)` and `Atc.Helpers.ProcessHelper.ExecuteAsync(System.IO.FileInfo,System.String,System.Boolean,System.UInt16,System.Threading.CancellationToken)`, this method uses `UseShellExecute = true` and does not capture standard output or error. This is suitable for launching GUI applications or detached processes.
+#### StartProcess
+>```csharp
+>Process StartProcess(DirectoryInfo workingDirectory, FileInfo fileInfo, string arguments = , bool runAsAdministrator = False)
+>```
+><b>Summary:</b> Starts a process without waiting for it to complete. Supports UAC elevation via the "runas" verb when `runAsAdministrator` is <see langword="true" />.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`fileInfo`&nbsp;&nbsp;-&nbsp;&nbsp;The executable file to run.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`arguments`&nbsp;&nbsp;-&nbsp;&nbsp;The command-line arguments to pass to the executable.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`runAsAdministrator`&nbsp;&nbsp;-&nbsp;&nbsp;If , launches the process with elevated privileges (triggers a UAC prompt on Windows).<br />
+>
+><b>Returns:</b> The started `System.Diagnostics.Process`, or <see langword="null" /> if the process could not be started.
+>
+><b>Remarks:</b> Unlike `Atc.Helpers.ProcessHelper.Execute(System.IO.FileInfo,System.String,System.Boolean,System.UInt16,System.Threading.CancellationToken)` and `Atc.Helpers.ProcessHelper.ExecuteAsync(System.IO.FileInfo,System.String,System.Boolean,System.UInt16,System.Threading.CancellationToken)`, this method uses `UseShellExecute = true` and does not capture standard output or error. This is suitable for launching GUI applications or detached processes.
 
 <br />
 

--- a/docs/CodeDoc/Atc/IndexExtended.md
+++ b/docs/CodeDoc/Atc/IndexExtended.md
@@ -4710,6 +4710,8 @@
      - KillById(int processId, int timeoutInSec = 30)
      - KillByName(string processName, bool allowMultiKill = True, int timeoutInSec = 30)
      - KillEntryCaller(int timeoutInSec = 30)
+     - StartProcess(DirectoryInfo workingDirectory, FileInfo fileInfo, string arguments = , bool runAsAdministrator = False)
+     - StartProcess(FileInfo fileInfo, string arguments = , bool runAsAdministrator = False)
 - [ReflectionHelper](Atc.Helpers.md#reflectionhelper)
   -  Static Methods
      - GetPrivateField(object target, string fieldName)

--- a/src/Atc/Helpers/ProcessHelper.cs
+++ b/src/Atc/Helpers/ProcessHelper.cs
@@ -353,6 +353,87 @@ public static class ProcessHelper
     }
 
     /// <summary>
+    /// Starts a process without waiting for it to complete.
+    /// Supports UAC elevation via the "runas" verb when <paramref name="runAsAdministrator"/> is <see langword="true"/>.
+    /// </summary>
+    /// <param name="fileInfo">The executable file to run.</param>
+    /// <param name="arguments">The command-line arguments to pass to the executable.</param>
+    /// <param name="runAsAdministrator">If <see langword="true"/>, launches the process with elevated privileges (triggers a UAC prompt on Windows).</param>
+    /// <returns>The started <see cref="Process"/>, or <see langword="null"/> if the process could not be started.</returns>
+    /// <remarks>
+    /// Unlike <see cref="Execute(FileInfo, string, bool, ushort, CancellationToken)"/> and <see cref="ExecuteAsync(FileInfo, string, bool, ushort, CancellationToken)"/>,
+    /// this method uses <c>UseShellExecute = true</c> and does not capture standard output or error.
+    /// This is suitable for launching GUI applications or detached processes.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="fileInfo"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FileNotFoundException">Thrown if the specified file does not exist.</exception>
+    public static Process? StartProcess(
+        FileInfo fileInfo,
+        string arguments = "",
+        bool runAsAdministrator = false)
+    {
+        if (fileInfo is null)
+        {
+            throw new ArgumentNullException(nameof(fileInfo));
+        }
+
+        if (!File.Exists(fileInfo.FullName))
+        {
+            throw new FileNotFoundException(nameof(fileInfo));
+        }
+
+        return InvokeStartProcess(
+            workingDirectory: null,
+            fileInfo,
+            arguments,
+            runAsAdministrator);
+    }
+
+    /// <summary>
+    /// Starts a process with the specified working directory without waiting for it to complete.
+    /// Supports UAC elevation via the "runas" verb when <paramref name="runAsAdministrator"/> is <see langword="true"/>.
+    /// </summary>
+    /// <param name="workingDirectory">The working directory for the process.</param>
+    /// <param name="fileInfo">The executable file to run.</param>
+    /// <param name="arguments">The command-line arguments to pass to the executable.</param>
+    /// <param name="runAsAdministrator">If <see langword="true"/>, launches the process with elevated privileges (triggers a UAC prompt on Windows).</param>
+    /// <returns>The started <see cref="Process"/>, or <see langword="null"/> if the process could not be started.</returns>
+    /// <remarks>
+    /// Unlike <see cref="Execute(DirectoryInfo, FileInfo, string, bool, ushort, CancellationToken)"/> and <see cref="ExecuteAsync(DirectoryInfo, FileInfo, string, bool, ushort, CancellationToken)"/>,
+    /// this method uses <c>UseShellExecute = true</c> and does not capture standard output or error.
+    /// This is suitable for launching GUI applications or detached processes.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="workingDirectory"/>, <paramref name="fileInfo"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FileNotFoundException">Thrown if the specified file does not exist.</exception>
+    public static Process? StartProcess(
+        DirectoryInfo workingDirectory,
+        FileInfo fileInfo,
+        string arguments = "",
+        bool runAsAdministrator = false)
+    {
+        if (workingDirectory is null)
+        {
+            throw new ArgumentNullException(nameof(workingDirectory));
+        }
+
+        if (fileInfo is null)
+        {
+            throw new ArgumentNullException(nameof(fileInfo));
+        }
+
+        if (!File.Exists(fileInfo.FullName))
+        {
+            throw new FileNotFoundException(nameof(fileInfo));
+        }
+
+        return InvokeStartProcess(
+            workingDirectory,
+            fileInfo,
+            arguments,
+            runAsAdministrator);
+    }
+
+    /// <summary>
     /// Terminates the entry assembly's process (the current application).
     /// </summary>
     /// <param name="timeoutInSec">The maximum time in seconds to wait for the process to terminate. Default is 30 seconds.</param>
@@ -800,6 +881,32 @@ public static class ProcessHelper
                     includeExceptionName: true),
                 ProcessId: processId);
         }
+    }
+
+    private static Process? InvokeStartProcess(
+        DirectoryInfo? workingDirectory,
+        FileInfo fileInfo,
+        string arguments,
+        bool runAsAdministrator)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileInfo.FullName,
+            Arguments = arguments,
+            UseShellExecute = true,
+        };
+
+        if (runAsAdministrator)
+        {
+            startInfo.Verb = "runas";
+        }
+
+        if (workingDirectory is not null && workingDirectory.Exists)
+        {
+            startInfo.WorkingDirectory = workingDirectory.FullName;
+        }
+
+        return Process.Start(startInfo);
     }
 
     private static Process CreateProcess(

--- a/src/Atc/Helpers/ProcessHelper.cs
+++ b/src/Atc/Helpers/ProcessHelper.cs
@@ -365,8 +365,9 @@ public static class ProcessHelper
     /// this method uses <c>UseShellExecute = true</c> and does not capture standard output or error.
     /// This is suitable for launching GUI applications or detached processes.
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="fileInfo"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="fileInfo"/> or <paramref name="arguments"/> is <see langword="null"/>.</exception>
     /// <exception cref="FileNotFoundException">Thrown if the specified file does not exist.</exception>
+    [SupportedOSPlatform("windows")]
     public static Process? StartProcess(
         FileInfo fileInfo,
         string arguments = "",
@@ -377,9 +378,14 @@ public static class ProcessHelper
             throw new ArgumentNullException(nameof(fileInfo));
         }
 
+        if (arguments is null)
+        {
+            throw new ArgumentNullException(nameof(arguments));
+        }
+
         if (!File.Exists(fileInfo.FullName))
         {
-            throw new FileNotFoundException(nameof(fileInfo));
+            throw new FileNotFoundException($"File not found: {fileInfo.FullName}", fileInfo.FullName);
         }
 
         return InvokeStartProcess(
@@ -403,8 +409,10 @@ public static class ProcessHelper
     /// this method uses <c>UseShellExecute = true</c> and does not capture standard output or error.
     /// This is suitable for launching GUI applications or detached processes.
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="workingDirectory"/>, <paramref name="fileInfo"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="workingDirectory"/>, <paramref name="fileInfo"/>, or <paramref name="arguments"/> is <see langword="null"/>.</exception>
+    /// <exception cref="DirectoryNotFoundException">Thrown if the specified working directory does not exist.</exception>
     /// <exception cref="FileNotFoundException">Thrown if the specified file does not exist.</exception>
+    [SupportedOSPlatform("windows")]
     public static Process? StartProcess(
         DirectoryInfo workingDirectory,
         FileInfo fileInfo,
@@ -416,14 +424,24 @@ public static class ProcessHelper
             throw new ArgumentNullException(nameof(workingDirectory));
         }
 
+        if (!workingDirectory.Exists)
+        {
+            throw new DirectoryNotFoundException($"Directory not found: {workingDirectory.FullName}");
+        }
+
         if (fileInfo is null)
         {
             throw new ArgumentNullException(nameof(fileInfo));
         }
 
+        if (arguments is null)
+        {
+            throw new ArgumentNullException(nameof(arguments));
+        }
+
         if (!File.Exists(fileInfo.FullName))
         {
-            throw new FileNotFoundException(nameof(fileInfo));
+            throw new FileNotFoundException($"File not found: {fileInfo.FullName}", fileInfo.FullName);
         }
 
         return InvokeStartProcess(
@@ -901,7 +919,7 @@ public static class ProcessHelper
             startInfo.Verb = "runas";
         }
 
-        if (workingDirectory is not null && workingDirectory.Exists)
+        if (workingDirectory is not null)
         {
             startInfo.WorkingDirectory = workingDirectory.FullName;
         }

--- a/test/Atc.Tests/Helpers/ProcessHelperTests.cs
+++ b/test/Atc.Tests/Helpers/ProcessHelperTests.cs
@@ -416,6 +416,7 @@ public class ProcessHelperTests
         // Assert
         Assert.NotNull(process);
         process.WaitForExit(5000);
+        Assert.Equal(0, process.ExitCode);
     }
 
     [Fact]
@@ -431,6 +432,7 @@ public class ProcessHelperTests
         // Assert
         Assert.NotNull(process);
         process.WaitForExit(5000);
+        Assert.Equal(0, process.ExitCode);
     }
 
     [Fact]
@@ -445,7 +447,7 @@ public class ProcessHelperTests
     public void StartProcess_Should_Throw_On_Missing_File()
     {
         // Arrange
-        var fileInfo = new FileInfo(@"C:\nonexistent_file_that_does_not_exist.exe");
+        var fileInfo = new FileInfo(Path.Combine(Path.GetTempPath(), "nonexistent_file.exe"));
 
         // Act & Assert
         Assert.Throws<FileNotFoundException>(() =>
@@ -461,5 +463,28 @@ public class ProcessHelperTests
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
             ProcessHelper.StartProcess(null!, fileInfo));
+    }
+
+    [Fact]
+    public void StartProcess_With_WorkingDirectory_Should_Throw_On_Null_FileInfo()
+    {
+        // Arrange
+        var directoryInfo = new DirectoryInfo(@"C:\");
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            ProcessHelper.StartProcess(directoryInfo, null!));
+    }
+
+    [Fact]
+    public void StartProcess_With_WorkingDirectory_Should_Throw_On_Missing_File()
+    {
+        // Arrange
+        var directoryInfo = new DirectoryInfo(Path.GetTempPath());
+        var fileInfo = new FileInfo(Path.Combine(Path.GetTempPath(), "nonexistent_file.exe"));
+
+        // Act & Assert
+        Assert.Throws<FileNotFoundException>(() =>
+            ProcessHelper.StartProcess(directoryInfo, fileInfo));
     }
 }

--- a/test/Atc.Tests/Helpers/ProcessHelperTests.cs
+++ b/test/Atc.Tests/Helpers/ProcessHelperTests.cs
@@ -403,4 +403,63 @@ public class ProcessHelperTests
         Assert.False(result.IsSuccessful);
         Assert.True(result.IsCancelled || result.IsTimedOut);
     }
+
+    [Fact]
+    public void StartProcess_With_FileInfo_Arguments()
+    {
+        // Arrange
+        var fileInfo = new FileInfo(@"C:\Windows\System32\cmd.exe");
+
+        // Act
+        using var process = ProcessHelper.StartProcess(fileInfo, "/c echo hello");
+
+        // Assert
+        Assert.NotNull(process);
+        process.WaitForExit(5000);
+    }
+
+    [Fact]
+    public void StartProcess_With_WorkingDirectory_FileInfo_Arguments()
+    {
+        // Arrange
+        var directoryInfo = new DirectoryInfo(@"C:\");
+        var fileInfo = new FileInfo(@"C:\Windows\System32\cmd.exe");
+
+        // Act
+        using var process = ProcessHelper.StartProcess(directoryInfo, fileInfo, "/c echo hello");
+
+        // Assert
+        Assert.NotNull(process);
+        process.WaitForExit(5000);
+    }
+
+    [Fact]
+    public void StartProcess_Should_Throw_On_Null_FileInfo()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            ProcessHelper.StartProcess(null!));
+    }
+
+    [Fact]
+    public void StartProcess_Should_Throw_On_Missing_File()
+    {
+        // Arrange
+        var fileInfo = new FileInfo(@"C:\nonexistent_file_that_does_not_exist.exe");
+
+        // Act & Assert
+        Assert.Throws<FileNotFoundException>(() =>
+            ProcessHelper.StartProcess(fileInfo));
+    }
+
+    [Fact]
+    public void StartProcess_With_WorkingDirectory_Should_Throw_On_Null_WorkingDirectory()
+    {
+        // Arrange
+        var fileInfo = new FileInfo(@"C:\Windows\System32\cmd.exe");
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            ProcessHelper.StartProcess(null!, fileInfo));
+    }
 }


### PR DESCRIPTION
#  Summary

  Adds fire-and-forget StartProcess methods to ProcessHelper for launching GUI applications or detached processes using UseShellExecute = true. Includes overloads with and without a working directory, UAC elevation support via the runas verb, and comprehensive input validation with guard clauses.

#  Changes

  :sparkles: Features

  - Add StartProcess(FileInfo, string, bool) overload for launching processes without waiting for completion
  - Add StartProcess(DirectoryInfo, FileInfo, string, bool) overload with working directory support
  - Support UAC elevation via runas verb when runAsAdministrator is true

  :lock: Security

  - Mark both StartProcess methods with [SupportedOSPlatform("windows")] since runas verb is Windows-specific
  - Add null guards for fileInfo, arguments, and workingDirectory parameters
  - Add DirectoryNotFoundException when working directory does not exist
  - Include actual file path in FileNotFoundException messages for easier diagnosis

  :memo: Documentation

  - Add comprehensive XML documentation with <summary>, <param>, <returns>, <remarks>, and <exception> tags
  - Update auto-generated API documentation in docs/CodeDoc/

  :white_check_mark: Tests

  - Add happy-path tests for both overloads with exit code assertion
  - Add guard clause tests for null fileInfo, null workingDirectory, and missing file scenarios
  - Use Path.GetTempPath() instead of hardcoded paths in missing-file tests