### PR TITLE
Add URI validation presets and string extension methods

### DIFF
--- a/docs/CodeDoc/Atc/IndexExtended.md
+++ b/docs/CodeDoc/Atc/IndexExtended.md
@@ -5308,6 +5308,9 @@
      - IsSentence(this string value)
      - IsStringFormatParametersBalanced(this string value, bool isNumeric = True)
      - IsTrue(this string value)
+     - IsUri(this string value)
+     - IsUriHttpOrHttps(this string value)
+     - IsUriOpcTcp(this string value)
      - IsWord(this string value)
 - [StringNullOrEmptyException](System.md#stringnulloremptyexception)
 - [SwitchCaseDefaultException](System.md#switchcasedefaultexception)
@@ -5421,9 +5424,17 @@
   -  Methods
      - IsValid(object value)
 - [UriAttribute](System.ComponentModel.DataAnnotations.md#uriattribute)
+  -  Static Fields
+     - UriAttribute Default
+     - UriAttribute HttpOrHttps
+     - UriAttribute OpcTcp
   -  Static Methods
+     - IsValidHttpOrHttps(object value)
+     - IsValidOpcTcp(object value)
      - TryIsValid(string value, UriAttribute attribute, out string errorMessage)
      - TryIsValid(string value, out string errorMessage)
+     - TryIsValidHttpOrHttps(string value, out string errorMessage)
+     - TryIsValidOpcTcp(string value, out string errorMessage)
   -  Properties
      - AllowFile
      - AllowFtp

--- a/docs/CodeDoc/Atc/System.ComponentModel.DataAnnotations.md
+++ b/docs/CodeDoc/Atc/System.ComponentModel.DataAnnotations.md
@@ -218,8 +218,45 @@ Validates that a property, field, or parameter contains a valid URI with an allo
 >public class UriAttribute : ValidationAttribute
 >```
 
+### Static Fields
+
+#### Default
+>```csharp
+>UriAttribute Default
+>```
+><b>Summary:</b> A default configuration that allows all URI schemes and does not require a value.
+#### HttpOrHttps
+>```csharp
+>UriAttribute HttpOrHttps
+>```
+><b>Summary:</b> A preset configuration that only allows HTTP and HTTPS schemes and requires a value.
+#### OpcTcp
+>```csharp
+>UriAttribute OpcTcp
+>```
+><b>Summary:</b> A preset configuration that only allows OPC TCP scheme (opc.tcp://) URIs and requires a value.
 ### Static Methods
 
+#### IsValidHttpOrHttps
+>```csharp
+>bool IsValidHttpOrHttps(object value)
+>```
+><b>Summary:</b> Validates whether the specified value is a valid HTTP or HTTPS URI.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value to validate.<br />
+>
+><b>Returns:</b> `true` if the value is a valid http:// or https:// URI; otherwise, `false`.
+#### IsValidOpcTcp
+>```csharp
+>bool IsValidOpcTcp(object value)
+>```
+><b>Summary:</b> Validates whether the specified value is a valid OPC TCP URI.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value to validate.<br />
+>
+><b>Returns:</b> `true` if the value is a valid opc.tcp:// URI; otherwise, `false`.
 #### TryIsValid
 >```csharp
 >bool TryIsValid(string value, out string errorMessage)
@@ -242,6 +279,28 @@ Validates that a property, field, or parameter contains a valid URI with an allo
 >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`errorMessage`&nbsp;&nbsp;-&nbsp;&nbsp;When validation fails, contains a message describing the validation error.<br />
 >
 ><b>Returns:</b> `true` if the value is a valid URI; otherwise, `false`.
+#### TryIsValidHttpOrHttps
+>```csharp
+>bool TryIsValidHttpOrHttps(string value, out string errorMessage)
+>```
+><b>Summary:</b> Attempts to validate the specified string as an HTTP or HTTPS URI.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The string value to validate.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`errorMessage`&nbsp;&nbsp;-&nbsp;&nbsp;When validation fails, contains a message describing the validation error.<br />
+>
+><b>Returns:</b> `true` if the value is a valid http:// or https:// URI; otherwise, `false`.
+#### TryIsValidOpcTcp
+>```csharp
+>bool TryIsValidOpcTcp(string value, out string errorMessage)
+>```
+><b>Summary:</b> Attempts to validate the specified string as an OPC TCP URI.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The string value to validate.<br />
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`errorMessage`&nbsp;&nbsp;-&nbsp;&nbsp;When validation fails, contains a message describing the validation error.<br />
+>
+><b>Returns:</b> `true` if the value is a valid opc.tcp:// URI; otherwise, `false`.
 ### Properties
 
 #### AllowFile

--- a/docs/CodeDoc/Atc/System.md
+++ b/docs/CodeDoc/Atc/System.md
@@ -3095,6 +3095,36 @@ StringHasIsExtensions.
 >
 ><b>Parameters:</b><br>
 >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The value.<br />
+#### IsUri
+>```csharp
+>bool IsUri(this string value)
+>```
+><b>Summary:</b> Determines whether the specified value is a valid URI with any supported scheme.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The string to validate.<br />
+>
+><b>Returns:</b> <see langword="true" /> if the value is a valid URI; otherwise, <see langword="false" />.
+#### IsUriHttpOrHttps
+>```csharp
+>bool IsUriHttpOrHttps(this string value)
+>```
+><b>Summary:</b> Determines whether the specified value is a valid HTTP or HTTPS URI.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The string to validate.<br />
+>
+><b>Returns:</b> <see langword="true" /> if the value is a valid http:// or https:// URI; otherwise, <see langword="false" />.
+#### IsUriOpcTcp
+>```csharp
+>bool IsUriOpcTcp(this string value)
+>```
+><b>Summary:</b> Determines whether the specified value is a valid OPC TCP URI.
+>
+><b>Parameters:</b><br>
+>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`value`&nbsp;&nbsp;-&nbsp;&nbsp;The string to validate.<br />
+>
+><b>Returns:</b> <see langword="true" /> if the value is a valid opc.tcp:// URI; otherwise, <see langword="false" />.
 #### IsWord
 >```csharp
 >bool IsWord(this string value)

--- a/src/Atc/Attributes/DataAnnotations/ValidationAttributes/UriAttribute.cs
+++ b/src/Atc/Attributes/DataAnnotations/ValidationAttributes/UriAttribute.cs
@@ -12,6 +12,39 @@ namespace System.ComponentModel.DataAnnotations;
 public sealed class UriAttribute : ValidationAttribute
 {
     /// <summary>
+    /// A default configuration that allows all URI schemes and does not require a value.
+    /// </summary>
+    public static readonly UriAttribute Default = new();
+
+    /// <summary>
+    /// A preset configuration that only allows HTTP and HTTPS schemes and requires a value.
+    /// </summary>
+    public static readonly UriAttribute HttpOrHttps = new()
+    {
+        Required = true,
+        AllowHttp = true,
+        AllowHttps = true,
+        AllowFtp = false,
+        AllowFtps = false,
+        AllowFile = false,
+        AllowOpcTcp = false,
+    };
+
+    /// <summary>
+    /// A preset configuration that only allows OPC TCP scheme (opc.tcp://) URIs and requires a value.
+    /// </summary>
+    public static readonly UriAttribute OpcTcp = new()
+    {
+        Required = true,
+        AllowHttp = false,
+        AllowHttps = false,
+        AllowFtp = false,
+        AllowFtps = false,
+        AllowFile = false,
+        AllowOpcTcp = true,
+    };
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="UriAttribute"/> class with all URI schemes allowed.
     /// </summary>
     public UriAttribute()
@@ -122,6 +155,22 @@ public sealed class UriAttribute : ValidationAttribute
     }
 
     /// <summary>
+    /// Validates whether the specified value is a valid HTTP or HTTPS URI.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <returns><c>true</c> if the value is a valid http:// or https:// URI; otherwise, <c>false</c>.</returns>
+    public static bool IsValidHttpOrHttps(object? value)
+        => HttpOrHttps.IsValid(value);
+
+    /// <summary>
+    /// Validates whether the specified value is a valid OPC TCP URI.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <returns><c>true</c> if the value is a valid opc.tcp:// URI; otherwise, <c>false</c>.</returns>
+    public static bool IsValidOpcTcp(object? value)
+        => OpcTcp.IsValid(value);
+
+    /// <summary>
     /// Attempts to validate the specified string as a URI using default validation settings (all schemes allowed).
     /// </summary>
     /// <param name="value">The string value to validate.</param>
@@ -172,4 +221,26 @@ public sealed class UriAttribute : ValidationAttribute
 
         return false;
     }
+
+    /// <summary>
+    /// Attempts to validate the specified string as an HTTP or HTTPS URI.
+    /// </summary>
+    /// <param name="value">The string value to validate.</param>
+    /// <param name="errorMessage">When validation fails, contains a message describing the validation error.</param>
+    /// <returns><c>true</c> if the value is a valid http:// or https:// URI; otherwise, <c>false</c>.</returns>
+    public static bool TryIsValidHttpOrHttps(
+        string value,
+        out string errorMessage)
+        => TryIsValid(value, HttpOrHttps, out errorMessage);
+
+    /// <summary>
+    /// Attempts to validate the specified string as an OPC TCP URI.
+    /// </summary>
+    /// <param name="value">The string value to validate.</param>
+    /// <param name="errorMessage">When validation fails, contains a message describing the validation error.</param>
+    /// <returns><c>true</c> if the value is a valid opc.tcp:// URI; otherwise, <c>false</c>.</returns>
+    public static bool TryIsValidOpcTcp(
+        string value,
+        out string errorMessage)
+        => TryIsValid(value, OpcTcp, out errorMessage);
 }

--- a/src/Atc/Extensions/StringHasIsExtensions.cs
+++ b/src/Atc/Extensions/StringHasIsExtensions.cs
@@ -8,9 +8,9 @@ namespace System;
 public static class StringHasIsExtensions
 {
 #if NET9_0_OR_GREATER
-    private static readonly System.Buffers.SearchValues<char> AlphaChars = System.Buffers.SearchValues.Create("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
-    private static readonly System.Buffers.SearchValues<char> AlphaNumericChars = System.Buffers.SearchValues.Create("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
-    private static readonly System.Buffers.SearchValues<char> NumericChars = System.Buffers.SearchValues.Create("0123456789");
+    private static readonly Buffers.SearchValues<char> AlphaChars = Buffers.SearchValues.Create("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    private static readonly Buffers.SearchValues<char> AlphaNumericChars = Buffers.SearchValues.Create("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+    private static readonly Buffers.SearchValues<char> NumericChars = Buffers.SearchValues.Create("0123456789");
 #else
     private static readonly Lazy<Regex> RxAlpha = new(() => new Regex("[^a-zA-Z]", RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromSeconds(1)));
     private static readonly Lazy<Regex> RxAlphaNumeric = new(() => new Regex("[^a-zA-Z0-9]", RegexOptions.Singleline | RegexOptions.Compiled, TimeSpan.FromSeconds(1)));
@@ -562,4 +562,28 @@ public static class StringHasIsExtensions
     public static bool IsEmailAddress(this string value)
         => !string.IsNullOrEmpty(value) &&
            RxEmailAddress.Value.IsMatch(value);
+
+    /// <summary>
+    /// Determines whether the specified value is a valid URI with any supported scheme.
+    /// </summary>
+    /// <param name="value">The string to validate.</param>
+    /// <returns><see langword="true" /> if the value is a valid URI; otherwise, <see langword="false" />.</returns>
+    public static bool IsUri(this string value)
+        => UriAttribute.Default.IsValid(value);
+
+    /// <summary>
+    /// Determines whether the specified value is a valid HTTP or HTTPS URI.
+    /// </summary>
+    /// <param name="value">The string to validate.</param>
+    /// <returns><see langword="true" /> if the value is a valid http:// or https:// URI; otherwise, <see langword="false" />.</returns>
+    public static bool IsUriHttpOrHttps(this string value)
+        => UriAttribute.IsValidHttpOrHttps(value);
+
+    /// <summary>
+    /// Determines whether the specified value is a valid OPC TCP URI.
+    /// </summary>
+    /// <param name="value">The string to validate.</param>
+    /// <returns><see langword="true" /> if the value is a valid opc.tcp:// URI; otherwise, <see langword="false" />.</returns>
+    public static bool IsUriOpcTcp(this string value)
+        => UriAttribute.IsValidOpcTcp(value);
 }

--- a/test/Atc.Tests/Attributes/DataAnnotations/ValidationAttributes/UriAttributeTests.cs
+++ b/test/Atc.Tests/Attributes/DataAnnotations/ValidationAttributes/UriAttributeTests.cs
@@ -93,4 +93,82 @@ public class UriAttributeTests
         Assert.Equal(expected, actual);
         Assert.Equal(expectedMessage, errorMessage);
     }
+
+    [Theory]
+    [InlineData(true, "http://dr.dk")]
+    [InlineData(true, "https://dr.dk")]
+    [InlineData(true, "http://www.dr.dk")]
+    [InlineData(true, "https://www.dr.dk")]
+    [InlineData(false, null)]
+    [InlineData(false, "")]
+    [InlineData(false, "ftp://dr.dk")]
+    [InlineData(false, "ftps://dr.dk")]
+    [InlineData(false, "file://c:/temp/file.txt")]
+    [InlineData(false, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    public void IsValidHttpOrHttps(
+        bool expected,
+        string? input)
+    {
+        // Act
+        var actual = UriAttribute.IsValidHttpOrHttps(input);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(true, "", "http://dr.dk")]
+    [InlineData(true, "", "https://dr.dk")]
+    [InlineData(false, "The value is not a valid Uri.", "ftp://dr.dk")]
+    [InlineData(false, "The value is not a valid Uri.", "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(false, "The value is not a valid Uri.", "")]
+    public void TryIsValidHttpOrHttps(
+        bool expected,
+        string expectedMessage,
+        string input)
+    {
+        // Act
+        var actual = UriAttribute.TryIsValidHttpOrHttps(input, out var errorMessage);
+
+        // Assert
+        Assert.Equal(expected, actual);
+        Assert.Equal(expectedMessage, errorMessage);
+    }
+
+    [Theory]
+    [InlineData(true, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(false, null)]
+    [InlineData(false, "")]
+    [InlineData(false, "https://dr.dk")]
+    [InlineData(false, "http://dr.dk")]
+    [InlineData(false, "ftp://dr.dk")]
+    [InlineData(false, "file://c:/temp/file.txt")]
+    public void IsValidOpcTcp(
+        bool expected,
+        string? input)
+    {
+        // Act
+        var actual = UriAttribute.IsValidOpcTcp(input);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(true, "", "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(false, "The value is not a valid Uri.", "https://dr.dk")]
+    [InlineData(false, "The value is not a valid Uri.", "http://dr.dk")]
+    [InlineData(false, "The value is not a valid Uri.", "")]
+    public void TryIsValidOpcTcp(
+        bool expected,
+        string expectedMessage,
+        string input)
+    {
+        // Act
+        var actual = UriAttribute.TryIsValidOpcTcp(input, out var errorMessage);
+
+        // Assert
+        Assert.Equal(expected, actual);
+        Assert.Equal(expectedMessage, errorMessage);
+    }
 }

--- a/test/Atc.Tests/Extensions/StringHasIsExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/StringHasIsExtensionsTests.cs
@@ -322,4 +322,38 @@ public class StringHasIsExtensionsTests
         bool expected,
         string input)
         => Assert.Equal(expected, input.IsEmailAddress());
+
+    [Theory]
+    [InlineData(true, "http://dr.dk")]
+    [InlineData(true, "https://dr.dk")]
+    [InlineData(true, "ftp://dr.dk")]
+    [InlineData(true, "file://c:/temp/file.txt")]
+    [InlineData(true, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(false, "httpx://dr.dk")]
+    [InlineData(false, "not-a-uri")]
+    public void IsUri(
+        bool expected,
+        string input)
+        => Assert.Equal(expected, input.IsUri());
+
+    [Theory]
+    [InlineData(true, "http://dr.dk")]
+    [InlineData(true, "https://dr.dk")]
+    [InlineData(false, "ftp://dr.dk")]
+    [InlineData(false, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(false, "not-a-uri")]
+    public void IsUriHttpOrHttps(
+        bool expected,
+        string input)
+        => Assert.Equal(expected, input.IsUriHttpOrHttps());
+
+    [Theory]
+    [InlineData(true, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(false, "http://dr.dk")]
+    [InlineData(false, "https://dr.dk")]
+    [InlineData(false, "not-a-uri")]
+    public void IsUriOpcTcp(
+        bool expected,
+        string input)
+        => Assert.Equal(expected, input.IsUriOpcTcp());
 }

--- a/test/Atc.Tests/Extensions/TypeExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/TypeExtensionsTests.cs
@@ -221,7 +221,7 @@ public class TypeExtensionsTests
     }
 
     [Theory]
-    [InlineData(17, typeof(UriAttribute))]
+    [InlineData(21, typeof(UriAttribute))]
     [InlineData(6, typeof(LogKeyValueItem))]
     public void GetPublicDeclaredOnlyMethods(
         int expected,


### PR DESCRIPTION
#  Summary

  Extends UriAttribute with reusable static presets (Default, HttpOrHttps, OpcTcp) and convenience validation methods, then exposes them as fluent string extension methods (IsUri(), IsUriHttpOrHttps(), IsUriOpcTcp()) in StringHasIsExtensions. This makes URI scheme validation easy to use both as data annotations and inline string checks.

#  Changes

  :sparkles: Features

  - Add Default, HttpOrHttps, and OpcTcp static preset configurations to UriAttribute
  - Add IsValidHttpOrHttps / IsValidOpcTcp static convenience methods on UriAttribute
  - Add TryIsValidHttpOrHttps / TryIsValidOpcTcp try-pattern methods with error messages
  - Add IsUri(), IsUriHttpOrHttps(), IsUriOpcTcp() string extension methods

  :memo: Documentation

  - Add XML documentation to all new public members
  - Update generated code documentation

  :white_check_mark: Tests

  - Add tests for IsValidHttpOrHttps and IsValidOpcTcp covering valid schemes, invalid schemes, null, and empty
  - Add tests for TryIsValidHttpOrHttps and TryIsValidOpcTcp verifying results and error messages
  - Add tests for IsUri, IsUriHttpOrHttps, IsUriOpcTcp string extensions
