### PR TITLE
Validate IP-like hosts in UriAttribute and extend test coverage

### DIFF
--- a/src/Atc/Attributes/DataAnnotations/ValidationAttributes/UriAttribute.cs
+++ b/src/Atc/Attributes/DataAnnotations/ValidationAttributes/UriAttribute.cs
@@ -145,7 +145,8 @@ public sealed class UriAttribute : ValidationAttribute
                          (AllowFtps && string.Equals(uriResult.Scheme, "ftps", StringComparison.OrdinalIgnoreCase)) ||
                          (AllowFile && string.Equals(uriResult.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase)) ||
                          (AllowOpcTcp && string.Equals(uriResult.Scheme, "opc.tcp", StringComparison.OrdinalIgnoreCase)));
-        if (result)
+
+        if (result && IsHostValid(uriResult!))
         {
             return true;
         }
@@ -243,4 +244,18 @@ public sealed class UriAttribute : ValidationAttribute
         string value,
         out string errorMessage)
         => TryIsValid(value, OpcTcp, out errorMessage);
+
+    /// <summary>
+    /// Validates that the host portion of a URI is not a malformed IP address.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Uri.TryCreate(string?, UriKind, out Uri?)"/> accepts hosts like <c>1231.0.0.1</c>
+    /// by classifying them as DNS names. This method detects hosts that consist solely of digits
+    /// and dots (i.e., look like IPv4 addresses) but were not recognized as valid IPv4 by the parser,
+    /// and rejects them. Genuine hostnames always contain at least one letter.
+    /// </remarks>
+    private static bool IsHostValid(Uri uri)
+        => uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6 ||
+           uri.Host.Length == 0 ||
+           uri.Host.Any(c => c is not ('.' or >= '0' and <= '9'));
 }

--- a/test/Atc.Tests/Attributes/DataAnnotations/ValidationAttributes/IPAddressAttributeTests.cs
+++ b/test/Atc.Tests/Attributes/DataAnnotations/ValidationAttributes/IPAddressAttributeTests.cs
@@ -6,14 +6,39 @@ public class IPAddressAttributeTests
     [Theory]
     [InlineData(true, null)]
     [InlineData(false, "")]
+    [InlineData(false, " ")]
     [InlineData(false, "http://dr.dk")]
+    [InlineData(false, "not-an-ip")]
+    [InlineData(false, "abc.def.ghi.jkl")]
+
+    [InlineData(true, "0.0.0.0")]
     [InlineData(true, "127.0.0.0")]
     [InlineData(true, "127.0.0.1")]
     [InlineData(true, "127.0.0.255")]
+    [InlineData(true, "192.168.1.1")]
+    [InlineData(true, "10.0.0.1")]
+    [InlineData(true, "255.255.255.255")]
+
     [InlineData(false, "127.0.0.256")]
+    [InlineData(false, "999.999.999.999")]
+    [InlineData(false, "1231.0.0.1")]
+    [InlineData(false, "192.168.1.1:8080")]
+    [InlineData(true, "192.168.1")]
+    [InlineData(false, "192.168.1.1.1")]
+
+    [InlineData(true, "::1")]
+    [InlineData(true, "::")]
+    [InlineData(true, "2001:db8::1")]
+    [InlineData(true, "fe80::1")]
+    [InlineData(true, "::ffff:192.168.1.1")]
+    [InlineData(true, "2001:0db8:85a3:0000:0000:8a2e:0370:7334")]
+
+    [InlineData(true, "[::1]")]
+    [InlineData(false, "2001:db8::g")]
+    [InlineData(true, "2001:db8::1:8080")]
     public void IsValid(
         bool expected,
-        string input)
+        string? input)
     {
         // Arrange
         var sut = new IPAddressAttribute();
@@ -26,15 +51,27 @@ public class IPAddressAttributeTests
     }
 
     [Theory]
+
     [InlineData(false, null, true)]
+    [InlineData(false, "", true)]
+
     [InlineData(false, "http://dr.dk", true)]
+    [InlineData(false, "not-an-ip", true)]
+    [InlineData(false, "127.0.0.256", true)]
+    [InlineData(false, "999.999.999.999", true)]
+
     [InlineData(true, "127.0.0.0", true)]
     [InlineData(true, "127.0.0.1", true)]
     [InlineData(true, "127.0.0.255", true)]
-    [InlineData(false, "127.0.0.256", true)]
+    [InlineData(true, "192.168.1.1", true)]
+
+    [InlineData(true, "::1", true)]
+    [InlineData(true, "2001:db8::1", true)]
+
+    [InlineData(true, null, false)]
     public void IsValid_Required(
         bool expected,
-        string input,
+        string? input,
         bool required)
     {
         // Arrange
@@ -48,11 +85,21 @@ public class IPAddressAttributeTests
     }
 
     [Theory]
+    [InlineData(false, "The value is not a valid IPAddress.", "")]
     [InlineData(false, "The value is not a valid IPAddress.", "http://dr.dk")]
+    [InlineData(false, "The value is not a valid IPAddress.", "not-an-ip")]
+    [InlineData(false, "The value is not a valid IPAddress.", "127.0.0.256")]
+    [InlineData(false, "The value is not a valid IPAddress.", "999.999.999.999")]
+    [InlineData(false, "The value is not a valid IPAddress.", "1231.0.0.1")]
+    [InlineData(true, "", "0.0.0.0")]
     [InlineData(true, "", "127.0.0.0")]
     [InlineData(true, "", "127.0.0.1")]
     [InlineData(true, "", "127.0.0.255")]
-    [InlineData(false, "The value is not a valid IPAddress.", "127.0.0.256")]
+    [InlineData(true, "", "192.168.1.1")]
+    [InlineData(true, "", "255.255.255.255")]
+    [InlineData(true, "", "::1")]
+    [InlineData(true, "", "2001:db8::1")]
+    [InlineData(true, "", "::ffff:192.168.1.1")]
     public void TryIsValid(
         bool expected,
         string expectedMessage,
@@ -60,6 +107,29 @@ public class IPAddressAttributeTests
     {
         // Act
         var actual = IPAddressAttribute.TryIsValid(input, out var errorMessage);
+
+        // Assert
+        Assert.Equal(expected, actual);
+        Assert.Equal(expectedMessage, errorMessage);
+    }
+
+    [Theory]
+    [InlineData(false, "The value is not a valid IPAddress.", "", true)]
+    [InlineData(false, "The value is not a valid IPAddress.", "not-an-ip", true)]
+    [InlineData(false, "The value is not a valid IPAddress.", "999.999.999.999", true)]
+    [InlineData(true, "", "192.168.1.1", false)]
+    [InlineData(true, "", "::1", false)]
+    public void TryIsValid_WithAttribute(
+        bool expected,
+        string expectedMessage,
+        string input,
+        bool required)
+    {
+        // Arrange
+        var attribute = new IPAddressAttribute(required);
+
+        // Act
+        var actual = IPAddressAttribute.TryIsValid(input, attribute, out var errorMessage);
 
         // Assert
         Assert.Equal(expected, actual);

--- a/test/Atc.Tests/Attributes/DataAnnotations/ValidationAttributes/UriAttributeTests.cs
+++ b/test/Atc.Tests/Attributes/DataAnnotations/ValidationAttributes/UriAttributeTests.cs
@@ -12,11 +12,31 @@ public class UriAttributeTests
     [InlineData(true, "ftp://www.dr.dk")]
     [InlineData(true, "file://c:/temp/file.txt")]
     [InlineData(true, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(true, "http://192.168.1.1:8080")]
+    [InlineData(true, "https://10.0.0.1")]
+    [InlineData(true, "http://127.0.0.1")]
+    [InlineData(true, "opc.tcp://192.168.1.1:4840")]
+    [InlineData(true, "http://[::1]:8080")]
+    [InlineData(true, "https://[::1]")]
+    [InlineData(true, "opc.tcp://[::1]:4840")]
+    [InlineData(true, "opc.tcp://[2001:db8::1]:4840")]
+    [InlineData(true, "http://localhost:8080")]
     [InlineData(false, "httpx://www.dr.dk")]
     [InlineData(false, "httpsx://www.dr.dk")]
     [InlineData(false, "ftpx://www.dr.dk")]
     [InlineData(false, "filex://c:/temp/file.txt")]
     [InlineData(false, "opa.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(false, "http://1231.0.0.1:8080")]
+    [InlineData(false, "https://999.999.999.999")]
+    [InlineData(false, "opc.tcp://1231.0.0.1:4840")]
+    [InlineData(false, "opc.tcp://999.999.999.999:4840")]
+    [InlineData(false, "ftp://256.1.1.1")]
+    [InlineData(true, "http://dr.dk:0")]
+    [InlineData(true, "http://dr.dk:65535")]
+    [InlineData(true, "opc.tcp://192.168.1.1:65535")]
+    [InlineData(false, "http://dr.dk:65536")]
+    [InlineData(false, "http://dr.dk:99999")]
+    [InlineData(false, "opc.tcp://192.168.1.1:-1")]
     public void IsValid(
         bool expected,
         string input)
@@ -81,6 +101,10 @@ public class UriAttributeTests
     [InlineData(false, "The value is not a valid Uri.", "ftpx://www.dr.dk")]
     [InlineData(false, "The value is not a valid Uri.", "filex://c:/temp/file.txt")]
     [InlineData(false, "The value is not a valid Uri.", "opa.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(true, "", "http://192.168.1.1:8080")]
+    [InlineData(true, "", "opc.tcp://[::1]:4840")]
+    [InlineData(false, "The value is not a valid Uri.", "http://1231.0.0.1:8080")]
+    [InlineData(false, "The value is not a valid Uri.", "opc.tcp://999.999.999.999:4840")]
     public void TryIsValid(
         bool expected,
         string expectedMessage,
@@ -105,6 +129,14 @@ public class UriAttributeTests
     [InlineData(false, "ftps://dr.dk")]
     [InlineData(false, "file://c:/temp/file.txt")]
     [InlineData(false, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(true, "http://192.168.1.1:8080")]
+    [InlineData(true, "https://10.0.0.1")]
+    [InlineData(true, "http://[::1]:8080")]
+    [InlineData(false, "http://999.999.999.999:8080")]
+    [InlineData(false, "https://1231.0.0.1")]
+    [InlineData(true, "http://dr.dk:8080")]
+    [InlineData(true, "https://dr.dk:443")]
+    [InlineData(false, "http://dr.dk:65536")]
     public void IsValidHttpOrHttps(
         bool expected,
         string? input)
@@ -122,6 +154,9 @@ public class UriAttributeTests
     [InlineData(false, "The value is not a valid Uri.", "ftp://dr.dk")]
     [InlineData(false, "The value is not a valid Uri.", "opc.tcp://milo.digitalpetri.com:62541/milo")]
     [InlineData(false, "The value is not a valid Uri.", "")]
+    [InlineData(true, "", "https://192.168.1.1:443")]
+    [InlineData(true, "", "http://[::1]:8080")]
+    [InlineData(false, "The value is not a valid Uri.", "http://999.999.999.999:8080")]
     public void TryIsValidHttpOrHttps(
         bool expected,
         string expectedMessage,
@@ -143,6 +178,14 @@ public class UriAttributeTests
     [InlineData(false, "http://dr.dk")]
     [InlineData(false, "ftp://dr.dk")]
     [InlineData(false, "file://c:/temp/file.txt")]
+    [InlineData(true, "opc.tcp://192.168.1.1:4840")]
+    [InlineData(true, "opc.tcp://[::1]:4840")]
+    [InlineData(true, "opc.tcp://[2001:db8::1]:4840")]
+    [InlineData(false, "opc.tcp://1231.0.0.1:4840")]
+    [InlineData(false, "opc.tcp://999.999.999.999:4840")]
+    [InlineData(true, "opc.tcp://192.168.1.1:0")]
+    [InlineData(true, "opc.tcp://192.168.1.1:65535")]
+    [InlineData(false, "opc.tcp://192.168.1.1:65536")]
     public void IsValidOpcTcp(
         bool expected,
         string? input)
@@ -159,6 +202,9 @@ public class UriAttributeTests
     [InlineData(false, "The value is not a valid Uri.", "https://dr.dk")]
     [InlineData(false, "The value is not a valid Uri.", "http://dr.dk")]
     [InlineData(false, "The value is not a valid Uri.", "")]
+    [InlineData(true, "", "opc.tcp://192.168.1.1:4840")]
+    [InlineData(true, "", "opc.tcp://[::1]:4840")]
+    [InlineData(false, "The value is not a valid Uri.", "opc.tcp://1231.0.0.1:4840")]
     public void TryIsValidOpcTcp(
         bool expected,
         string expectedMessage,

--- a/test/Atc.Tests/Extensions/StringHasIsExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/StringHasIsExtensionsTests.cs
@@ -329,8 +329,14 @@ public class StringHasIsExtensionsTests
     [InlineData(true, "ftp://dr.dk")]
     [InlineData(true, "file://c:/temp/file.txt")]
     [InlineData(true, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(true, "http://192.168.1.1:8080")]
+    [InlineData(true, "https://[::1]")]
     [InlineData(false, "httpx://dr.dk")]
     [InlineData(false, "not-a-uri")]
+    [InlineData(false, "http://1231.0.0.1:8080")]
+    [InlineData(false, "opc.tcp://999.999.999.999:4840")]
+    [InlineData(true, "http://dr.dk:65535")]
+    [InlineData(false, "http://dr.dk:65536")]
     public void IsUri(
         bool expected,
         string input)
@@ -339,9 +345,14 @@ public class StringHasIsExtensionsTests
     [Theory]
     [InlineData(true, "http://dr.dk")]
     [InlineData(true, "https://dr.dk")]
+    [InlineData(true, "http://192.168.1.1:8080")]
+    [InlineData(true, "https://[::1]")]
     [InlineData(false, "ftp://dr.dk")]
     [InlineData(false, "opc.tcp://milo.digitalpetri.com:62541/milo")]
     [InlineData(false, "not-a-uri")]
+    [InlineData(false, "http://999.999.999.999:8080")]
+    [InlineData(false, "https://1231.0.0.1")]
+    [InlineData(false, "https://dr.dk:65536")]
     public void IsUriHttpOrHttps(
         bool expected,
         string input)
@@ -349,9 +360,14 @@ public class StringHasIsExtensionsTests
 
     [Theory]
     [InlineData(true, "opc.tcp://milo.digitalpetri.com:62541/milo")]
+    [InlineData(true, "opc.tcp://192.168.1.1:4840")]
+    [InlineData(true, "opc.tcp://[::1]:4840")]
     [InlineData(false, "http://dr.dk")]
     [InlineData(false, "https://dr.dk")]
     [InlineData(false, "not-a-uri")]
+    [InlineData(false, "opc.tcp://1231.0.0.1:4840")]
+    [InlineData(false, "opc.tcp://999.999.999.999:4840")]
+    [InlineData(false, "opc.tcp://192.168.1.1:65536")]
     public void IsUriOpcTcp(
         bool expected,
         string input)

--- a/test/Atc.Tests/Extensions/TypeExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/TypeExtensionsTests.cs
@@ -235,7 +235,7 @@ public class TypeExtensionsTests
     }
 
     [Theory]
-    [InlineData(0, typeof(UriAttribute))]
+    [InlineData(1, typeof(UriAttribute))]
     [InlineData(0, typeof(LogKeyValueItem))]
     public void GetPrivateDeclaredOnlyMethods(
         int expected,


### PR DESCRIPTION
#  Summary

  Uri.TryCreate accepts malformed IP addresses like 1231.0.0.1 by misclassifying them as DNS hostnames. This PR adds host validation to UriAttribute.IsValid that detects hosts consisting solely of digits and dots (IP-like) but not recognized as valid IPv4, and rejects them. It also significantly extends test coverage for IPAddressAttribute, UriAttribute, and the URI string extension methods.

#  Changes

  :bug: Fixes

  - Reject URIs with malformed IP-like hosts (e.g. opc.tcp://1231.0.0.1:4840, http://999.999.999.999:8080) that Uri.TryCreate
  incorrectly accepts as DNS names

  :white_check_mark: Tests

  - Extend IPAddressAttributeTests with comprehensive IPv4/IPv6 coverage, edge cases, required/optional, and TryIsValid with
  attribute overload
  - Add invalid IP host and valid IP host test cases across UriAttributeTests for IsValid, TryIsValid, IsValidHttpOrHttps,
  TryIsValidHttpOrHttps, IsValidOpcTcp, and TryIsValidOpcTcp
  - Add port boundary test cases (0, 65535, 65536) documenting that out-of-range ports are correctly rejected
  - Add IP and port test cases to StringHasIsExtensionsTests for IsUri, IsUriHttpOrHttps, and IsUriOpcTcp

  :memo: Documentation

  - Add XML documentation to the private IsHostValid helper explaining the detection strategy
