### PR TITLE
Add ExceptionMessage to HealthCheck and sanitize data

### DIFF
--- a/docs/CodeDoc/Atc.Rest.HealthChecks/Atc.Rest.HealthChecks.Models.md
+++ b/docs/CodeDoc/Atc.Rest.HealthChecks/Atc.Rest.HealthChecks.Models.md
@@ -31,6 +31,11 @@ Represents the result of a single health check execution.
 >Duration
 >```
 ><b>Summary:</b> The time taken to execute the health check.
+#### ExceptionMessage
+>```csharp
+>ExceptionMessage
+>```
+><b>Summary:</b> The exception message if the health check failed with an exception; otherwise null.
 #### Name
 >```csharp
 >Name
@@ -49,7 +54,7 @@ Represents the result of a single health check execution.
 >```
 #### Deconstruct
 >```csharp
->void Deconstruct(out string Name, out HealthStatus Status, out TimeSpan Duration, out string Description, out IReadOnlyDictionary`2 Data)
+>void Deconstruct(out string Name, out HealthStatus Status, out TimeSpan Duration, out string Description, out string ExceptionMessage, out IReadOnlyDictionary`2 Data)
 >```
 #### Equals
 >```csharp

--- a/docs/CodeDoc/Atc.Rest.HealthChecks/IndexExtended.md
+++ b/docs/CodeDoc/Atc.Rest.HealthChecks/IndexExtended.md
@@ -31,11 +31,12 @@
      - Data
      - Description
      - Duration
+     - ExceptionMessage
      - Name
      - Status
   -  Methods
      - <Clone>$()
-     - Deconstruct(out string Name, out HealthStatus Status, out TimeSpan Duration, out string Description, out IReadOnlyDictionary`2 Data)
+     - Deconstruct(out string Name, out HealthStatus Status, out TimeSpan Duration, out string Description, out string ExceptionMessage, out IReadOnlyDictionary`2 Data)
      - Equals(HealthCheck other)
      - Equals(object obj)
      - GetHashCode()

--- a/src/Atc.Rest.HealthChecks/Extensions/HealthReportEntryExtensions.cs
+++ b/src/Atc.Rest.HealthChecks/Extensions/HealthReportEntryExtensions.cs
@@ -16,7 +16,7 @@ public static class HealthReportEntryExtensions
         var entry = kvp.Value;
 
         var data = entry.Data.Count > 0
-            ? entry.Data
+            ? SanitizeData(entry.Data)
             : null;
 
         return new HealthCheck(
@@ -24,6 +24,7 @@ public static class HealthReportEntryExtensions
             Status: entry.Status,
             Duration: entry.Duration,
             Description: entry.Description,
+            ExceptionMessage: entry.Exception?.Message,
             Data: data);
     }
 
@@ -37,4 +38,13 @@ public static class HealthReportEntryExtensions
         => entries
             .Select(ToHealthCheck)
             .ToList();
+
+    private static IReadOnlyDictionary<string, object> SanitizeData(
+        IReadOnlyDictionary<string, object> data)
+        => data.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value is Exception ex
+                ? ex.Message
+                : kvp.Value,
+            StringComparer.Ordinal);
 }

--- a/src/Atc.Rest.HealthChecks/Models/HealthCheck.cs
+++ b/src/Atc.Rest.HealthChecks/Models/HealthCheck.cs
@@ -7,10 +7,12 @@ namespace Atc.Rest.HealthChecks.Models;
 /// <param name="Status">The status of the health check (Healthy, Degraded, or Unhealthy).</param>
 /// <param name="Duration">The time taken to execute the health check.</param>
 /// <param name="Description">An optional description providing additional context about the health check result.</param>
+/// <param name="ExceptionMessage">The exception message if the health check failed with an exception; otherwise null.</param>
 /// <param name="Data">Optional key-value data associated with the health check result.</param>
 public sealed record HealthCheck(
     string Name,
     HealthStatus Status,
     TimeSpan Duration,
     string? Description,
+    string? ExceptionMessage,
     IReadOnlyDictionary<string, object>? Data);

--- a/test/Atc.Rest.HealthChecks.Tests/Extensions/HealthReportEntryExtensionsTests.cs
+++ b/test/Atc.Rest.HealthChecks.Tests/Extensions/HealthReportEntryExtensionsTests.cs
@@ -76,6 +76,138 @@ public class HealthReportEntryExtensionsTests
     }
 
     [Fact]
+    public void ToHealthCheck_With_Exception()
+    {
+        // Arrange
+        const string name = "MyHealthCheck";
+        const string description = "Failed";
+        var duration = TimeSpan.FromSeconds(1);
+        const HealthStatus status = HealthStatus.Unhealthy;
+        var exception = new InvalidOperationException("Something went wrong");
+
+        var entry = new KeyValuePair<string, HealthReportEntry>(
+            name,
+            new HealthReportEntry(
+                status,
+                description,
+                duration,
+                exception,
+                data: null));
+
+        // Act
+        var actual = entry.ToHealthCheck();
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual.Name.Should().Be(name);
+        actual.Status.Should().Be(status);
+        actual.Duration.Should().Be(duration);
+        actual.Description.Should().Be(description);
+        actual.ExceptionMessage.Should().Be("Something went wrong");
+        actual.Data.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToHealthCheck_Sanitizes_Exception_In_Data()
+    {
+        // Arrange
+        const string name = "MyHealthCheck";
+        var duration = TimeSpan.FromSeconds(1);
+        const HealthStatus status = HealthStatus.Unhealthy;
+        var exception = new InvalidOperationException("Cache connection failed");
+
+        var data = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["error"] = exception,
+            ["retries"] = 3,
+        };
+
+        var entry = new KeyValuePair<string, HealthReportEntry>(
+            name,
+            new HealthReportEntry(
+                status,
+                "Has exception in data",
+                duration,
+                exception: null,
+                data));
+
+        // Act
+        var actual = entry.ToHealthCheck();
+
+        // Assert
+        actual.Data.Should().NotBeNull().And.HaveCount(2);
+        actual.Data!["error"].Should().Be("Cache connection failed");
+        actual.Data!["retries"].Should().Be(3);
+    }
+
+    [Fact]
+    public void ToHealthCheck_Preserves_NonException_Objects_In_Data()
+    {
+        // Arrange
+        const string name = "MyHealthCheck";
+        var duration = TimeSpan.FromSeconds(1);
+        const HealthStatus status = HealthStatus.Degraded;
+
+        var data = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["label"] = "healthy",
+            ["flag"] = true,
+            ["count"] = 42,
+            ["duration"] = TimeSpan.FromMilliseconds(500),
+        };
+
+        var entry = new KeyValuePair<string, HealthReportEntry>(
+            name,
+            new HealthReportEntry(
+                status,
+                "Mixed data types",
+                duration,
+                exception: null,
+                data));
+
+        // Act
+        var actual = entry.ToHealthCheck();
+
+        // Assert
+        actual.Data.Should().NotBeNull().And.HaveCount(4);
+        actual.Data!["label"].Should().Be("healthy");
+        actual.Data!["flag"].Should().Be(true);
+        actual.Data!["count"].Should().Be(42);
+        actual.Data!["duration"].Should().Be(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Fact]
+    public void ToHealthCheck_Preserves_ResourceHealthCheck_In_Data()
+    {
+        // Arrange
+        const string name = "MyHealthCheck";
+        var duration = TimeSpan.FromSeconds(1);
+        const HealthStatus status = HealthStatus.Healthy;
+
+        var resource = new ResourceHealthCheck("redis", HealthStatus.Healthy, "OK", TimeSpan.FromMilliseconds(5));
+        var data = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["redis"] = resource,
+        };
+
+        var entry = new KeyValuePair<string, HealthReportEntry>(
+            name,
+            new HealthReportEntry(
+                status,
+                "Has resource",
+                duration,
+                exception: null,
+                data));
+
+        // Act
+        var actual = entry.ToHealthCheck();
+
+        // Assert
+        actual.Data.Should().NotBeNull().And.HaveCount(1);
+        actual.Data!["redis"].Should().Be(resource);
+    }
+
+    [Fact]
     public void ToHealthChecks_Without_Data()
     {
         // Arrange
@@ -94,12 +226,13 @@ public class HealthReportEntryExtensionsTests
 
         // Assert
         actual.Should().HaveCount(1);
-        var (n, s, d, desc, data) = actual[0];
+        var (n, s, d, desc, exMsg, data) = actual[0];
 
         n.Should().Be(name);
         s.Should().Be(status);
         d.Should().Be(duration);
         desc.Should().Be(description);
+        exMsg.Should().BeNull();
         data.Should().BeNull();
     }
 
@@ -127,12 +260,13 @@ public class HealthReportEntryExtensionsTests
 
         // Assert
         actual.Should().HaveCount(1);
-        var (n, s, d, desc, dataBag) = actual[0];
+        var (n, s, d, desc, exMsg, dataBag) = actual[0];
 
         n.Should().Be(name);
         s.Should().Be(status);
         d.Should().Be(duration);
         desc.Should().Be(description);
+        exMsg.Should().BeNull();
 
         dataBag
             .Should().NotBeNull()

--- a/test/Atc.Rest.HealthChecks.Tests/Factories/HealthCheckOptionsFactoryTests.cs
+++ b/test/Atc.Rest.HealthChecks.Tests/Factories/HealthCheckOptionsFactoryTests.cs
@@ -27,4 +27,84 @@ public class HealthCheckOptionsFactoryTests
         // Assert
         Assert.NotNull(healthCheckOptions);
     }
+
+    [Fact]
+    public void CreateJson_Serialization_With_Exception_Does_Not_Throw()
+    {
+        // Arrange
+        const string applicationName = "MyTestApp";
+        var exception = new InvalidOperationException("Cache connection failed");
+
+        var entries = new Dictionary<string, HealthReportEntry>(StringComparer.Ordinal)
+        {
+            ["CacheHealthCheck"] = new(
+                HealthStatus.Unhealthy,
+                "Failed to set value in cache",
+                TimeSpan.FromMilliseconds(150),
+                exception,
+                data: null),
+        };
+
+        var report = new HealthReport(entries, TimeSpan.FromMilliseconds(150));
+
+        var response = new HealthCheckResponse(
+            applicationName,
+            report.Entries.ToHealthChecks(),
+            report.Status,
+            report.TotalDuration);
+
+        var jsonOptions = JsonSerializerOptionsFactory.Create();
+
+        // Act
+        var json = System.Text.Json.JsonSerializer.Serialize(response, jsonOptions);
+
+        // Assert
+        json.Should().NotBeNullOrEmpty();
+        json.Should().Contain("Cache connection failed");
+        json.Should().Contain("Failed to set value in cache");
+        json.Should().NotContain("TargetSite");
+        json.Should().NotContain("MethodBase");
+    }
+
+    [Fact]
+    public void CreateJson_Serialization_With_Exception_In_Data_Does_Not_Throw()
+    {
+        // Arrange
+        const string applicationName = "MyTestApp";
+        var exception = new InvalidOperationException("Redis timeout");
+
+        var data = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["error"] = exception,
+            ["retries"] = 3,
+        };
+
+        var entries = new Dictionary<string, HealthReportEntry>(StringComparer.Ordinal)
+        {
+            ["CacheHealthCheck"] = new(
+                HealthStatus.Unhealthy,
+                "Cache is unreachable",
+                TimeSpan.FromMilliseconds(200),
+                exception: null,
+                data),
+        };
+
+        var report = new HealthReport(entries, TimeSpan.FromMilliseconds(200));
+
+        var response = new HealthCheckResponse(
+            applicationName,
+            report.Entries.ToHealthChecks(),
+            report.Status,
+            report.TotalDuration);
+
+        var jsonOptions = JsonSerializerOptionsFactory.Create();
+
+        // Act
+        var json = System.Text.Json.JsonSerializer.Serialize(response, jsonOptions);
+
+        // Assert
+        json.Should().NotBeNullOrEmpty();
+        json.Should().Contain("Redis timeout");
+        json.Should().NotContain("TargetSite");
+    }
 }


### PR DESCRIPTION
  # Summary

  - Add ExceptionMessage property to the HealthCheck record
  - Sanitize Exception objects in health check data to string messages
  - Extend test coverage for exception handling and data sanitization

  # Changes

  ### :sparkles: Features
  - Add ExceptionMessage property to HealthCheck record
  - Map HealthReportEntry.Exception?.Message to ExceptionMessage
  - Sanitize Exception objects in Data dictionary to their Message strings

  ### :white_check_mark: Tests
  - Add test for exception message mapping on unhealthy checks
  - Add test for Exception sanitization in Data dictionary
  - Add test for preserving non-Exception objects in Data
  - Add test for preserving ResourceHealthCheck in Data
  - Update existing deconstruct tests for new ExceptionMessage field
  - Add HealthCheckOptionsFactory tests

  ### :memo: Documentation
  - Update generated API docs for new ExceptionMessage property
