### PR TITLE
Include per-project README.md in all NuGet packages

### DIFF
--- a/src/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.csproj
+++ b/src/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.csproj
@@ -5,11 +5,16 @@
     <PackageId>Atc.CodeAnalysis.CSharp</PackageId>
     <PackageTags>netstandard;codeanalysis</PackageTags>
     <Description>Atc.CodeAnalysis.CSharp is a collection of classes and extension methods for Microsoft.CodeAnalysis.CSharp.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.CodeDocumentation/Atc.CodeDocumentation.csproj
+++ b/src/Atc.CodeDocumentation/Atc.CodeDocumentation.csproj
@@ -5,10 +5,15 @@
     <PackageId>Atc.CodeDocumentation</PackageId>
     <PackageTags>netstandard;documentation;code</PackageTags>
     <Description>Atc.CodeDocumentation is a markdown generator for source code.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Atc\Atc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Console.Spectre/Atc.Console.Spectre.csproj
+++ b/src/Atc.Console.Spectre/Atc.Console.Spectre.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.Console.Spectre</PackageId>
     <PackageTags>netstandard;console</PackageTags>
     <Description>Atc.Console.Spectre is a collection of classes and extension methods for Spectre.Console.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc\Atc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.DotNet/Atc.DotNet.csproj
+++ b/src/Atc.DotNet/Atc.DotNet.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.DotNet</PackageId>
     <PackageTags>dotnet,build</PackageTags>
     <Description>Atc.DotNet is a collection of helper method for working with dotnet.exe.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -13,6 +14,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc\Atc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.OpenApi/Atc.OpenApi.csproj
+++ b/src/Atc.OpenApi/Atc.OpenApi.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.OpenApi</PackageId>
     <PackageTags>openapi;extension</PackageTags>
     <Description>Atc.OpenApi is a collection of classes and extension methods for Microsoft.OpenApi.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +14,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc\Atc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Rest.AwesomeAssertions/Atc.Rest.AwesomeAssertions.csproj
+++ b/src/Atc.Rest.AwesomeAssertions/Atc.Rest.AwesomeAssertions.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.Rest.AwesomeAssertions</PackageId>
     <PackageTags>rest;awesomeassertions</PackageTags>
     <Description>Atc.Rest.AwesomeAssertions is a collection of assertion helpers for writing tests of Atc types.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,6 +18,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc.Rest\Atc.Rest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Rest.Extended/Atc.Rest.Extended.csproj
+++ b/src/Atc.Rest.Extended/Atc.Rest.Extended.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.Rest.Extended</PackageId>
     <PackageTags>api;rest;extended</PackageTags>
     <Description>Atc.Rest.Extended is a collection of classes and extension methods for Atc.Rest, that contains SwaggerUI, FluentValidation Versioning etc.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc.Rest\Atc.Rest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.csproj
+++ b/src/Atc.Rest.FluentAssertions/Atc.Rest.FluentAssertions.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.Rest.FluentAssertions</PackageId>
     <PackageTags>rest;fluentassertions</PackageTags>
     <Description>Atc.Rest.FluentAssertions is a collection of assertion helpers for writing tests of Atc types.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,6 +18,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc.Rest\Atc.Rest.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Rest.HealthChecks/Atc.Rest.HealthChecks.csproj
+++ b/src/Atc.Rest.HealthChecks/Atc.Rest.HealthChecks.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.Rest.HealthChecks</PackageId>
     <PackageTags>api;rest;healthchecks</PackageTags>
     <Description>Atc.Rest.HealthChecks is a collection of classes, extension methods and factories for working with HealthChecks in an ASP.NET core application.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc\Atc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Rest/Atc.Rest.csproj
+++ b/src/Atc.Rest/Atc.Rest.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.Rest</PackageId>
     <PackageTags>api;rest</PackageTags>
     <Description>Atc.Rest is a basic collection of classes and extension methods for ASP.NET Core WebApi.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Atc\Atc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.XUnit/Atc.XUnit.csproj
+++ b/src/Atc.XUnit/Atc.XUnit.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc.XUnit</PackageId>
     <PackageTags>xunit;test</PackageTags>
     <Description>Atc.XUnit is a collection of helper method for code compliance of documentation and tests.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -29,6 +30,10 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Atc.XUnit.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc/Atc.csproj
+++ b/src/Atc/Atc.csproj
@@ -5,6 +5,7 @@
     <PackageId>Atc</PackageId>
     <PackageTags>netstandard;common</PackageTags>
     <Description>Atc is a collection of classes and extension methods for common functionality.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateSatelliteAssemblies>true</GenerateSatelliteAssemblies>
   </PropertyGroup>
 
@@ -77,6 +78,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Summary

- Packages were published without a readme on the NuGet gallery
- Each src project already ships its own README.md; pack it
- Resolves the NuGet "Readme missing" warning for all 12 packages

# Changes

### :wrench: Configuration
- Set PackageReadmeFile to README.md in every src project
- Pack each project's own README.md into the package root
- Applies to all 12 published packages