### PR TITLE
feat(atc): enforce RFC 1123 TLD all-numeric rejection in IsHostName

### DIFF
--- a/src/Atc/Extensions/StringHasIsExtensions.cs
+++ b/src/Atc/Extensions/StringHasIsExtensions.cs
@@ -598,11 +598,26 @@ public static class StringHasIsExtensions
     /// Accepts single-label names (e.g. <c>localhost</c>) and an optional trailing dot (e.g. <c>example.com.</c>).
     /// Each label is 1-63 ASCII alphanumeric/hyphen characters and may not start or end with a hyphen;
     /// the total length is limited to 253 characters. Underscores and raw Unicode (non-punycode IDN) are not allowed.
+    /// Per RFC 1123 §2.1 the top-level (right-most) label must not be all-numeric, which also disambiguates
+    /// host names from IPv4 addresses (e.g. <c>192.168.0.27</c> is rejected).
     /// This is a purely syntactic check and does not perform any DNS resolution.
     /// </remarks>
     public static bool IsHostName(this string value)
-        => !string.IsNullOrEmpty(value) &&
-           RxHostName.Value.IsMatch(value);
+    {
+        if (string.IsNullOrEmpty(value) ||
+            !RxHostName.Value.IsMatch(value))
+        {
+            return false;
+        }
+
+        var host = value.EndsWith('.')
+            ? value[..^1]
+            : value;
+
+        var topLevelLabel = host[(host.LastIndexOf('.') + 1)..];
+
+        return !topLevelLabel.All(char.IsDigit);
+    }
 
     /// <summary>
     /// Determines whether the specified value is a valid IPv4 address.

--- a/test/Atc.Tests/Extensions/StringHasIsExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/StringHasIsExtensionsTests.cs
@@ -384,6 +384,7 @@ public class StringHasIsExtensionsTests
     [InlineData(true, "example.com.")]
     [InlineData(true, "a.b.c.d.e.f")]
     [InlineData(true, "xn--mnchen-3ya.de")]
+    [InlineData(true, "host123")]
     [InlineData(false, "")]
     [InlineData(false, " ")]
     [InlineData(false, "-leadinghyphen.com")]
@@ -392,6 +393,10 @@ public class StringHasIsExtensionsTests
     [InlineData(false, "double..dot.com")]
     [InlineData(false, "space in.host")]
     [InlineData(false, "münchen.de")]
+    [InlineData(false, "192.168.0.27")]
+    [InlineData(false, "1.2.3.4")]
+    [InlineData(false, "123")]
+    [InlineData(false, "example.123")]
     public void IsHostName(
         bool expected,
         string input)


### PR DESCRIPTION
  # Summary

  - Apply RFC 1123 §2.1 rule: top-level label must not be all-numeric
  - Ensures IPv4 addresses (e.g. 192.168.0.27) are rejected by IsHostName
  - Fixes ambiguity between hostnames and numeric IPv4-like strings

  # Changes

  ### :sparkles: Features
  - Reject hostnames whose TLD is all-numeric per RFC 1123 §2.1
  - Single-label all-numeric values (e.g. "123") are now rejected

  ### :bug: Fixes
  - IPv4 addresses no longer pass IsHostName (e.g. 192.168.0.27)
  - "example.123" and similar numeric-TLD strings now return false

  ### :memo: Documentation
  - Update IsHostName remarks to document the RFC 1123 TLD rule

  ### :art: Styling
  - Expand IsHostName from expression-body to block for logic clarity
