### PR TITLE
Fix duplicate diagnostic counts and middleware cancellation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -599,9 +599,12 @@ dotnet_diagnostic.S3267.severity = suggestion		# Simplified with LINQ expression
 dotnet_diagnostic.S4456.severity = none		        # Split method into two - one validating the parameters and one handling the iterator
 dotnet_diagnostic.S4457.severity = none             # Split this method into two, one handling parameters check and the other handling the asynchronous code
 dotnet_diagnostic.S4487.severity = none             # Remove this unread private field 'testOutputHelper' or refactor the code to use its value.
+dotnet_diagnostic.S5766.severity = none             # Validate data in this deserialization constructor. These types are [Serializable] for legacy interop only - none implements ISerializable, and BinaryFormatter is removed in modern .NET.
 dotnet_diagnostic.S6562.severity = suggestion       # Provide the "DateTimeKind" when creating this object
 dotnet_diagnostic.S6588.severity = suggestion       # Use "DateTime.UnixEpoch" instead of creating DateTime instances that point to the unix epoch time
 dotnet_diagnostic.S6608.severity = none             # Indexing at 0 should be used instead of the "Enumerable" extension method "First"
+dotnet_diagnostic.S8969.severity = none             # Remove this null-forgiving operator; the compiler already knows this expression is not null here.
+dotnet_diagnostic.S8970.severity = none             # Remove this null-forgiving operator; nullable warnings are disabled here.
 
 dotnet_diagnostic.IDE0079.severity = suggestion		# Remove unnecessary suppression (not working with all SonarSource) - https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0079
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,9 +42,9 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="Atc.Analyzer" Version="0.1.23" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.109" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.136" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/docs/CodeDoc/Atc/Atc.Helpers.md
+++ b/docs/CodeDoc/Atc/Atc.Helpers.md
@@ -184,6 +184,13 @@ The AssemblyHelper module contains procedures used to preform assembly operation
 ><b>Summary:</b> Gets the system version.
 >
 ><b>Returns:</b> System version.
+#### GetSystemVersion
+>```csharp
+>string GetSystemVersion(int fieldCount)
+>```
+><b>Summary:</b> Gets the system version.
+>
+><b>Returns:</b> System version.
 #### Load
 >```csharp
 >Assembly Load(FileInfo assemblyFile)

--- a/docs/CodeDoc/Atc/IndexExtended.md
+++ b/docs/CodeDoc/Atc/IndexExtended.md
@@ -4431,6 +4431,7 @@
      - GetSystemName()
      - GetSystemNameAsKebabCasing()
      - GetSystemVersion()
+     - GetSystemVersion(int fieldCount)
      - Load(FileInfo assemblyFile)
      - ReadAsBytes(FileInfo assemblyFile)
 - [ByteHelper](Atc.Helpers.md#bytehelper)

--- a/docs/CodeDoc/Atc/System.md
+++ b/docs/CodeDoc/Atc/System.md
@@ -3307,7 +3307,7 @@ StringHasIsExtensions.
 >
 ><b>Returns:</b> <see langword="true" /> if the value is a valid host name; otherwise, <see langword="false" />.
 >
-><b>Remarks:</b> Accepts single-label names (e.g. `localhost`) and an optional trailing dot (e.g. `example.com.`). Each label is 1-63 ASCII alphanumeric/hyphen characters and may not start or end with a hyphen; the total length is limited to 253 characters. Underscores and raw Unicode (non-punycode IDN) are not allowed. This is a purely syntactic check and does not perform any DNS resolution.
+><b>Remarks:</b> Accepts single-label names (e.g. `localhost`) and an optional trailing dot (e.g. `example.com.`). Each label is 1-63 ASCII alphanumeric/hyphen characters and may not start or end with a hyphen; the total length is limited to 253 characters. Underscores and raw Unicode (non-punycode IDN) are not allowed. Per RFC 1123 §2.1 the top-level (right-most) label must not be all-numeric, which also disambiguates host names from IPv4 addresses (e.g. `192.168.0.27` is rejected). This is a purely syntactic check and does not perform any DNS resolution.
 #### IsIPAddress
 >```csharp
 >bool IsIPAddress(this string value)

--- a/sample/Demo.Atc.Console.Spectre.Cli/Demo.Atc.Console.Spectre.Cli.csproj
+++ b/sample/Demo.Atc.Console.Spectre.Cli/Demo.Atc.Console.Spectre.Cli.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Spectre.Console" Version="0.57.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Spectre.Console" Version="0.57.2" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
   </ItemGroup>
 

--- a/sample/Demo.Atc.Dotnet.Cli/Demo.Atc.Dotnet.Cli.csproj
+++ b/sample/Demo.Atc.Dotnet.Cli/Demo.Atc.Dotnet.Cli.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Spectre.Console" Version="0.57.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Spectre.Console" Version="0.57.2" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
   </ItemGroup>
 

--- a/src/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.csproj
+++ b/src/Atc.CodeAnalysis.CSharp/Atc.CodeAnalysis.CSharp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Atc.Console.Spectre/Atc.Console.Spectre.csproj
+++ b/src/Atc.Console.Spectre/Atc.Console.Spectre.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="Spectre.Console" Version="0.57.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Spectre.Console" Version="0.57.2" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
   </ItemGroup>
 

--- a/src/Atc.DotNet/DotnetBuildHelper.cs
+++ b/src/Atc.DotNet/DotnetBuildHelper.cs
@@ -14,6 +14,8 @@ public static class DotnetBuildHelper
 
     private static readonly ConcurrentDictionary<string, Regex> RegexCache = new(StringComparer.Ordinal);
 
+    private static readonly string[] LineSeparators = ["\r\n", "\n", "\r"];
+
     /// <summary>
     /// Builds a .NET project or solution and collects compilation errors grouped by error code.
     /// </summary>
@@ -358,6 +360,21 @@ public static class DotnetBuildHelper
         return ParseBuildOutputHelper(buildResult, patternGeneral);
     }
 
+    /// <summary>
+    /// Counts diagnostics by code, ignoring repeats of the same diagnostic.
+    /// </summary>
+    /// <remarks>
+    /// MSBuild reports every diagnostic twice — inline while the target runs, and again in the
+    /// end-of-build recap under <c>(CoreCompile target) -&gt;</c>. Neither <c>-clp:NoSummary</c>
+    /// nor <c>-tl:off</c> removes the recap, so counting every regex match doubled every
+    /// occurrence.
+    /// <para>
+    /// The de-duplication key is the whole normalised line rather than the matched fragment. The
+    /// patterns start at <c>": error "</c> / <c>": warning "</c> and therefore exclude the file and
+    /// position, so keying on the fragment would collapse two genuine occurrences of the same rule
+    /// at different positions into one.
+    /// </para>
+    /// </remarks>
     private static Dictionary<string, int> ParseBuildOutputHelper(
         string buildResult,
         string regexPattern,
@@ -370,17 +387,25 @@ public static class DotnetBuildHelper
             RegexOptions.Multiline | RegexOptions.Compiled,
             TimeSpan.FromSeconds(10)));
 
-        var matchCollection = regex.Matches(buildResult);
-        foreach (var matchGroups in matchCollection.Select(x => x.Groups))
+        var seenDiagnostics = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var line in buildResult.Split(LineSeparators, StringSplitOptions.RemoveEmptyEntries))
         {
-            if (matchGroups.Count != 3)
+            var match = regex.Match(line);
+            if (!match.Success ||
+                match.Groups.Count != 3)
+            {
+                continue;
+            }
+
+            if (!seenDiagnostics.Add(NormalizeDiagnosticLine(line)))
             {
                 continue;
             }
 
             var key = keyPrefix is null
-                ? matchGroups[1].Value
-                : keyPrefix + matchGroups[1].Value;
+                ? match.Groups[1].Value
+                : keyPrefix + match.Groups[1].Value;
 
             if (!errors.TryAdd(key, 1))
             {
@@ -389,5 +414,23 @@ public static class DotnetBuildHelper
         }
 
         return errors;
+    }
+
+    /// <summary>
+    /// Strips surrounding whitespace and any leading MSBuild node id (<c>"1&gt;"</c>), so the inline
+    /// copy of a diagnostic and its recap copy normalise to the same text.
+    /// </summary>
+    private static string NormalizeDiagnosticLine(string line)
+    {
+        var trimmed = line.Trim();
+
+        var nodeSeparatorIndex = trimmed.IndexOf('>', StringComparison.Ordinal);
+        if (nodeSeparatorIndex > 0 &&
+            trimmed[..nodeSeparatorIndex].All(char.IsDigit))
+        {
+            trimmed = trimmed[(nodeSeparatorIndex + 1)..].TrimStart();
+        }
+
+        return trimmed;
     }
 }

--- a/src/Atc.Rest.AwesomeAssertions/Atc.Rest.AwesomeAssertions.csproj
+++ b/src/Atc.Rest.AwesomeAssertions/Atc.Rest.AwesomeAssertions.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest.HealthChecks/Atc.Rest.HealthChecks.csproj
+++ b/src/Atc.Rest.HealthChecks/Atc.Rest.HealthChecks.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest/Middleware/KeepAliveMiddleware.cs
+++ b/src/Atc.Rest/Middleware/KeepAliveMiddleware.cs
@@ -43,7 +43,10 @@ public class KeepAliveMiddleware
         if (IsKeepAlivePing(context.Request))
         {
             context.Response.StatusCode = (int)HttpStatusCode.OK;
-            await context.Response.WriteAsync(nameof(HttpStatusCode.OK));
+
+            // This is the response body itself, so honour the request's cancellation: if the
+            // caller has already hung up there is nothing to be gained by writing it.
+            await context.Response.WriteAsync(nameof(HttpStatusCode.OK), context.RequestAborted);
             return;
         }
 

--- a/src/Atc.Rest/Middleware/RequestResponseLoggerMiddleware.cs
+++ b/src/Atc.Rest/Middleware/RequestResponseLoggerMiddleware.cs
@@ -97,11 +97,17 @@ public class RequestResponseLoggerMiddleware
         {
             try
             {
+                // CancellationToken.None is deliberate for the whole block below, and must not be
+                // "corrected" to httpContext.RequestAborted. This runs after the response has been
+                // produced: it copies the buffered body back into the real response stream and
+                // restores httpContext.Response.Body. Honouring the request's cancellation would
+                // abort that copy part-way when a client disconnects, leaving a truncated response,
+                // an unrestored Body and an incomplete log entry.
                 if (logModel.Response.ContentType is not null &&
                     IsBinaryContent(logModel.Response.ContentType))
                 {
                     swapStream.Seek(0, SeekOrigin.Begin);
-                    await swapStream.CopyToAsync(originalResponseBody);
+                    await swapStream.CopyToAsync(originalResponseBody, CancellationToken.None);
                     httpContext.Response.Body = originalResponseBody;
 
                     logModel.Response.Body = BinaryDataRedactedString;
@@ -112,11 +118,11 @@ public class RequestResponseLoggerMiddleware
                     string responseBodyText;
                     using (var reader = new StreamReader(swapStream, leaveOpen: true))
                     {
-                        responseBodyText = await reader.ReadToEndAsync();
+                        responseBodyText = await reader.ReadToEndAsync(CancellationToken.None);
                     }
 
                     swapStream.Seek(0, SeekOrigin.Begin);
-                    await swapStream.CopyToAsync(originalResponseBody);
+                    await swapStream.CopyToAsync(originalResponseBody, CancellationToken.None);
                     httpContext.Response.Body = originalResponseBody;
 
                     StripBinaryContentPartFromRequestResponseBody(ref responseBodyText);

--- a/src/Atc.XUnit/Atc.XUnit.csproj
+++ b/src/Atc.XUnit/Atc.XUnit.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="[7.5.3]" /> <!-- EPPlus is version-pinned because versions newer than 7.5.3 require a paid license -->
-    <PackageReference Include="ICSharpCode.Decompiler" Version="10.1.0.8386" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="10.1.1.8388" />
     <PackageReference Include="Mono.Reflection" Version="2.0.0">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>

--- a/src/Atc/Atc.csproj
+++ b/src/Atc/Atc.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Polyfill" Version="1.0.153">
+    <PackageReference Include="Meziantou.Polyfill" Version="1.0.158">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.9" />
+    <PackageReference Include="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>
@@ -77,7 +77,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc/Helpers/AssemblyHelper.cs
+++ b/src/Atc/Helpers/AssemblyHelper.cs
@@ -1,3 +1,4 @@
+// ReSharper disable CommentTypo
 namespace Atc.Helpers;
 
 /// <summary>
@@ -166,6 +167,29 @@ public static class AssemblyHelper
     {
         var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
         return assembly.GetFileVersion();
+    }
+
+    /// <summary>
+    /// Gets the system version formatted as a string with the specified number of components.
+    /// </summary>
+    /// <param name="fieldCount">
+    /// The number of version components to include (1-4). Pass 3 for SemVer-style
+    /// "Major.Minor.Patch" formatting, which discards build-height/revision components added
+    /// by tools like Nerdbank.GitVersioning.
+    /// </param>
+    /// <returns>The system version as a string (e.g., "1.0.6").</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="fieldCount"/> is not between 1 and 4.</exception>
+    public static string GetSystemVersion(int fieldCount)
+    {
+        if (fieldCount is < 1 or > 4)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(fieldCount),
+                fieldCount,
+                "Field count must be between 1 and 4.");
+        }
+
+        return GetSystemVersion().ToString(fieldCount);
     }
 
     /// <summary>

--- a/src/Atc/Helpers/InternetBrowserHelper.cs
+++ b/src/Atc/Helpers/InternetBrowserHelper.cs
@@ -292,6 +292,7 @@ public static class InternetBrowserHelper
     }
 
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "OK.")]
+    [SuppressMessage("Design", "S4036:Use an absolute path", Justification = "OK.")]
     private static bool ProcessStartOpenUrl(Uri uri)
     {
         if (uri is null)

--- a/src/Atc/Helpers/NetworkInformationHelper.cs
+++ b/src/Atc/Helpers/NetworkInformationHelper.cs
@@ -13,6 +13,7 @@ public static class NetworkInformationHelper
     /// Determines whether there is network connectivity by pinging Google's DNS server (8.8.8.8).
     /// </summary>
     /// <returns><see langword="true"/> if a ping response is received; otherwise, <see langword="false"/>.</returns>
+    [SuppressMessage("Design", "S1313:Magic numbers should not be used", Justification = "OK - By design.")]
     public static bool HasConnection()
     {
         const string googleDns = "8.8.8.8";
@@ -153,6 +154,7 @@ public static class NetworkInformationHelper
     /// </summary>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns><see langword="true"/> if a ping response is received; otherwise, <see langword="false"/>.</returns>
+    [SuppressMessage("Design", "S1313:Magic numbers should not be used", Justification = "OK - By design.")]
     public static Task<bool> HasConnectionAsync(
         CancellationToken cancellationToken = default)
     {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,8 +53,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.85" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/Atc.CodeAnalysis.CSharp.Tests/SyntaxFactories/SyntaxClassDeclarationFactoryTests.cs
+++ b/test/Atc.CodeAnalysis.CSharp.Tests/SyntaxFactories/SyntaxClassDeclarationFactoryTests.cs
@@ -15,7 +15,7 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.NotNull(result);
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.Single(result.Modifiers);
-        Assert.Contains("public", result.Modifiers.Select(m => m.ValueText));
+        Assert.Contains("public", result.Modifiers.Select(m => m.ValueText), StringComparer.Ordinal);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.NotNull(result);
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.NotNull(result.BaseList);
-        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()));
+        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()), StringComparer.Ordinal);
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.NotNull(result.BaseList);
         Assert.Single(result.BaseList.Types);
-        Assert.Contains(interfaceName, result.BaseList.Types.Select(t => t.Type.ToString()));
+        Assert.Contains(interfaceName, result.BaseList.Types.Select(t => t.Type.ToString()), StringComparer.Ordinal);
     }
 
     [Fact]
@@ -69,8 +69,8 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.NotNull(result.BaseList);
         Assert.Equal(2, result.BaseList.Types.Count);
-        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()));
-        Assert.Contains(interfaceName, result.BaseList.Types.Select(t => t.Type.ToString()));
+        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()), StringComparer.Ordinal);
+        Assert.Contains(interfaceName, result.BaseList.Types.Select(t => t.Type.ToString()), StringComparer.Ordinal);
     }
 
     [Fact]
@@ -82,8 +82,8 @@ public class SyntaxClassDeclarationFactoryTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(2, result.Modifiers.Count);
-        Assert.Contains("partial", result.Modifiers.Select(item => item.ValueText));
-        Assert.Contains("public", result.Modifiers.Select(item => item.ValueText));
+        Assert.Contains("partial", result.Modifiers.Select(item => item.ValueText), StringComparer.Ordinal);
+        Assert.Contains("public", result.Modifiers.Select(item => item.ValueText), StringComparer.Ordinal);
     }
 
     [Fact]
@@ -99,8 +99,8 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.NotNull(result);
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.Equal(2, result.Modifiers.Count);
-        Assert.Contains("public", result.Modifiers.Select(m => m.ValueText));
-        Assert.Contains("static", result.Modifiers.Select(m => m.ValueText));
+        Assert.Contains("public", result.Modifiers.Select(m => m.ValueText), StringComparer.Ordinal);
+        Assert.Contains("static", result.Modifiers.Select(m => m.ValueText), StringComparer.Ordinal);
     }
 
     [Fact]
@@ -116,8 +116,8 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.NotNull(result);
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.Equal(2, result.Modifiers.Count);
-        Assert.Contains("internal", result.Modifiers.Select(m => m.ValueText));
-        Assert.Contains("static", result.Modifiers.Select(m => m.ValueText));
+        Assert.Contains("internal", result.Modifiers.Select(m => m.ValueText), StringComparer.Ordinal);
+        Assert.Contains("static", result.Modifiers.Select(m => m.ValueText), StringComparer.Ordinal);
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.NotNull(result);
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.NotNull(result.BaseList);
-        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()));
+        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()), StringComparer.Ordinal);
         Assert.NotEmpty(result.AttributeLists);
     }
 
@@ -218,7 +218,7 @@ public class SyntaxClassDeclarationFactoryTests
         Assert.NotNull(result);
         Assert.Equal(className, result.Identifier.ValueText);
         Assert.NotNull(result.BaseList);
-        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()));
+        Assert.Contains(baseClassName, result.BaseList.Types.Select(t => t.Type.ToString()), StringComparer.Ordinal);
         Assert.NotEmpty(result.AttributeLists);
     }
 

--- a/test/Atc.DotNet.Tests/DotnetBuildHelperTests.cs
+++ b/test/Atc.DotNet.Tests/DotnetBuildHelperTests.cs
@@ -196,6 +196,107 @@ public class DotnetBuildHelperTests : IAsyncLifetime
         Assert.Empty(warnings);
     }
 
+    [Fact]
+    public void ParseWarnings_DuplicateIdenticalLines_CountedOnce()
+    {
+        // MSBuild prints each diagnostic twice: inline during CoreCompile and again in the
+        // end-of-build recap. -clp:NoSummary does not remove the recap, so the parser has to
+        // recognise the repeat itself.
+        const string output = """
+            Program.cs(5,5): warning CS0168: Unused var [Test.csproj]
+            Program.cs(5,5): warning CS0168: Unused var [Test.csproj]
+            """;
+
+        var warnings = DotnetBuildHelper.ParseWarnings(output);
+
+        Assert.Single(warnings);
+        Assert.Equal(1, warnings["CS0168"]);
+    }
+
+    [Fact]
+    public void ParseErrors_DuplicateIdenticalLines_CountedOnce()
+    {
+        const string output = """
+            Program.cs(13,13): error CS0246: The type 'Foo' could not be found [Test.csproj]
+            Program.cs(13,13): error CS0246: The type 'Foo' could not be found [Test.csproj]
+            """;
+
+        var errors = DotnetBuildHelper.ParseErrors(output);
+
+        Assert.Single(errors);
+        Assert.Equal(1, errors["CS0246"]);
+    }
+
+    [Fact]
+    public void ParseWarnings_DuplicateWithDifferentMsBuildNodePrefix_CountedOnce()
+    {
+        // At higher verbosity the inline copy carries a node prefix ("1>") and the recap copy is
+        // indented, so the two are not byte-identical.
+        const string output = """
+                 1>Program.cs(5,5): warning CS0168: Unused var [Test.csproj]
+                   Program.cs(5,5): warning CS0168: Unused var [Test.csproj]
+            """;
+
+        var warnings = DotnetBuildHelper.ParseWarnings(output);
+
+        Assert.Single(warnings);
+        Assert.Equal(1, warnings["CS0168"]);
+    }
+
+    [Fact]
+    public void ParseWarnings_SameCodeAtDifferentPositions_CountedSeparately()
+    {
+        // Deduplication must key on the whole line, not the matched fragment: these differ only
+        // in position, and both are real occurrences.
+        const string output = """
+            Program.cs(5,5): warning CS0168: Unused var [Test.csproj]
+            Program.cs(6,5): warning CS0168: Unused var [Test.csproj]
+            """;
+
+        var warnings = DotnetBuildHelper.ParseWarnings(output);
+
+        Assert.Equal(2, warnings["CS0168"]);
+    }
+
+    [Fact]
+    public void ParseWarnings_SameMessageFromDifferentProjects_CountedSeparately()
+    {
+        const string output = """
+            ProjA.csproj : warning NU1701: Package 'OldPkg 1.0.0' was restored using net472.
+            ProjB.csproj : warning NU1701: Package 'OldPkg 1.0.0' was restored using net472.
+            """;
+
+        var warnings = DotnetBuildHelper.ParseWarnings(output);
+
+        Assert.Equal(2, warnings["NU1701"]);
+    }
+
+    [Fact]
+    public void ParseWarnings_RealSolutionOutput_CountsEachSiteOnce()
+    {
+        // Shape captured from 'dotnet build <solution> -c Release -p:TreatWarningsAsErrors=false
+        // -v q -clp:NoSummary' on a two-project solution holding 7 CS0219 sites, 2 in ProjA and 5
+        // in ProjB. MSBuild emits 14 lines for those 7 sites.
+        var lines = new[]
+        {
+            "/repro/src/ProjA/ClassA.cs(1,45): warning CS0219: The variable 'a' is assigned but its value is never used [/repro/src/ProjA/ProjA.csproj]",
+            "/repro/src/ProjA/ClassA.cs(1,56): warning CS0219: The variable 'b' is assigned but its value is never used [/repro/src/ProjA/ProjA.csproj]",
+            "/repro/src/ProjB/ClassB.cs(1,45): warning CS0219: The variable 'a' is assigned but its value is never used [/repro/src/ProjB/ProjB.csproj]",
+            "/repro/src/ProjB/ClassB.cs(1,54): warning CS0219: The variable 'b' is assigned but its value is never used [/repro/src/ProjB/ProjB.csproj]",
+            "/repro/src/ProjB/ClassB.cs(1,63): warning CS0219: The variable 'c' is assigned but its value is never used [/repro/src/ProjB/ProjB.csproj]",
+            "/repro/src/ProjB/ClassB.cs(1,72): warning CS0219: The variable 'd' is assigned but its value is never used [/repro/src/ProjB/ProjB.csproj]",
+            "/repro/src/ProjB/ClassB.cs(1,81): warning CS0219: The variable 'e' is assigned but its value is never used [/repro/src/ProjB/ProjB.csproj]",
+        };
+
+        // Every diagnostic appears twice: once inline, once in the end-of-build recap.
+        var output = string.Join(Environment.NewLine, lines.Concat(lines));
+
+        var warnings = DotnetBuildHelper.ParseWarnings(output);
+
+        Assert.Single(warnings);
+        Assert.Equal(7, warnings["CS0219"]);
+    }
+
     private static Task CreateCsprojFile(DirectoryInfo workingDirectory)
     {
         var file = new FileInfo(Path.Combine(workingDirectory.FullName, "Test.csproj"));

--- a/test/Atc.Rest.Tests/Extensions/HeaderDictionaryExtensionsTests.cs
+++ b/test/Atc.Rest.Tests/Extensions/HeaderDictionaryExtensionsTests.cs
@@ -50,7 +50,7 @@ public class HeaderDictionaryExtensionsTests
         // Assert
         Assert.NotNull(actual);
         Assert.True(Guid.TryParse(actual, out _));
-        Assert.NotEqual("not-a-guid", actual);
+        Assert.NotEqual("not-a-guid", actual, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/test/Atc.Tests/Extensions/StringExtensionsTests.cs
+++ b/test/Atc.Tests/Extensions/StringExtensionsTests.cs
@@ -110,7 +110,7 @@ public class StringExtensionsTests
     public void GetStringFormatParameterTemplatePlaceholders(
         string[] expected,
         string input)
-        => Assert.Equal(expected, input.GetStringFormatParameterTemplatePlaceholders());
+        => Assert.Equal(expected, input.GetStringFormatParameterTemplatePlaceholders(), StringComparer.Ordinal);
 
     [Theory]
     [InlineData(new string[] { }, "Hallo World", true)]
@@ -123,7 +123,7 @@ public class StringExtensionsTests
         string[] expected,
         string input,
         bool useDoubleBracket)
-        => Assert.Equal(expected, input.GetStringFormatParameterTemplatePlaceholders(useDoubleBracket));
+        => Assert.Equal(expected, input.GetStringFormatParameterTemplatePlaceholders(useDoubleBracket), StringComparer.Ordinal);
 
     [Theory]
     [InlineData("Hallo World John-Doe-42", "Hallo World {{0}}-{{1}}-{{A1}}", new[] { "0", "John", "1", "Doe", "A1", "42" })]

--- a/test/Atc.Tests/Helpers/AssemblyHelperTests.cs
+++ b/test/Atc.Tests/Helpers/AssemblyHelperTests.cs
@@ -75,6 +75,49 @@ public class AssemblyHelperTests
         Assert.NotNull(actual);
     }
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void GetSystemVersion_String_FieldCount(int fieldCount)
+    {
+        // Arrange
+        var version = AssemblyHelper.GetSystemVersion();
+
+        // Act
+        var actual = AssemblyHelper.GetSystemVersion(fieldCount);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(version.ToString(fieldCount), actual);
+        Assert.Equal(fieldCount - 1, actual.Count(c => c == '.'));
+    }
+
+    [Fact]
+    public void GetSystemVersion_String_SemVer_HasThreeFields()
+    {
+        // Act
+        var actual = AssemblyHelper.GetSystemVersion(fieldCount: 3);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(2, actual.Count(c => c == '.'));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(5)]
+    [InlineData(int.MaxValue)]
+    public void GetSystemVersion_String_FieldCount_OutOfRange_Throws(
+        int fieldCount)
+    {
+        // Act + Assert
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => AssemblyHelper.GetSystemVersion(fieldCount));
+    }
+
     [Fact]
     public void GetSystemLocation()
     {

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="Atc.Test" Version="3.0.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Summary

- Count each build diagnostic once instead of twice
- Forward request cancellation in Atc.Rest middleware
- Add GetSystemVersion overload for SemVer-style output
- Update NuGet packages and suppress noisy analyzer rules

# Changes

### :sparkles: Features

- Add `GetSystemVersion(int fieldCount)` on `AssemblyHelper`
- Validate the field count is between 1 and 4
- Lets callers request `Major.Minor.Patch` directly

### :bug: Fixes

- Count each build diagnostic once in `ParseBuildOutputHelper`
- MSBuild prints every diagnostic twice, doubling every count
- Neither `-clp:NoSummary` nor `-tl:off` removes the recap copy
- Key de-duplication on the whole line, not the matched fragment
- Strip a leading MSBuild node id so both copies normalise alike
- Pass `context.RequestAborted` in `KeepAliveMiddleware`
- Pass `CancellationToken.None` in the request/response logger

### :package: Dependencies

- Update NuGet packages across src, test and samples

### :wrench: Configuration

- Suppress S5766 in the custom `.editorconfig` section
- Suppress S4036 in `InternetBrowserHelper`
- Suppress S1313 twice in `NetworkInformationHelper`

### :art: Styling

- Pass `StringComparer.Ordinal` to `Assert.Contains` on strings

### :memo: Documentation

- Regenerate `System.md` for the `IsHostName` RFC 1123 remarks
- Regenerate CodeDoc for the new `GetSystemVersion` overload

# Notes

- The logger middleware opts out of cancellation deliberately
- Those calls run after the response has been produced
- Cancelling there truncates the response and the log entry
- A code comment records this so it is not "corrected" later
- Consumers of the diagnostic counts should expect halved values
- `atc-coding-rules-updater` reported 7 real sites as 14 before
- That repo needs a release of this package to pick the fix up
- `AppDomainExtensionsTests.GetAssemblyInformations` fails
- It is pre-existing and unrelated, verified at `origin/main`
- The test recounts loaded assemblies after calling the helper
- The first call loads one more, so the baseline is always +1